### PR TITLE
feat(model-mapping): add sealed interface support to DSL codegen

### DIFF
--- a/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/ModelMappingCodegenSpec.kt
+++ b/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/ModelMappingCodegenSpec.kt
@@ -1,6 +1,7 @@
 package zygarde.codegen.dsl
 
 import zygarde.codegen.meta.CodegenDto
+import zygarde.codegen.meta.CodegenSealedInterface
 
 abstract class ModelMappingCodegenSpec(buildMapping: ModelMappingCodegenSpec.() -> Unit) : ModelMappingDslCodegen() {
   companion object {
@@ -27,5 +28,9 @@ abstract class ModelMappingCodegenSpec(buildMapping: ModelMappingCodegenSpec.() 
         groupInvokingDto.remove()
       }
     }
+  }
+
+  fun sealedInterface(name: String, dsl: SealedInterfaceSpec.() -> Unit): CodegenSealedInterface {
+    return SealedInterfaceSpec(name).also(dsl).build().also(sealedInterfaces::add)
   }
 }

--- a/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/ModelMappingDslCodegen.kt
+++ b/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/ModelMappingDslCodegen.kt
@@ -1,9 +1,11 @@
 package zygarde.codegen.dsl
 
 import zygarde.codegen.dsl.model.internal.DtoFieldMapping
+import zygarde.codegen.meta.CodegenSealedInterface
 
 abstract class ModelMappingDslCodegen {
   val dtoFieldMappings = mutableListOf<DtoFieldMapping>()
+  val sealedInterfaces = mutableListOf<CodegenSealedInterface>()
 
   open fun execute() {}
 }

--- a/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/ModelMappingDslMain.kt
+++ b/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/ModelMappingDslMain.kt
@@ -43,8 +43,9 @@ fun main() {
   modelMappingCodegenList.forEach { it.execute() }
 
   val dtoFieldMappings = modelMappingCodegenList.flatMap { it.dtoFieldMappings }
+  val sealedInterfaces = modelMappingCodegenList.flatMap { it.sealedInterfaces }
 
-  val result = DtoFieldMappingCodeGenerator(dtoFieldMappings)
+  val result = DtoFieldMappingCodeGenerator(dtoFieldMappings, sealedInterfaces)
     .generateFileSpec()
 
   result.dtoFileSpecs.writeSpecToFileOrSysOut("zygarde.codegen.dsl.dto.write-to")

--- a/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/SealedInterfaceSpec.kt
+++ b/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/SealedInterfaceSpec.kt
@@ -1,0 +1,16 @@
+package zygarde.codegen.dsl
+
+import zygarde.codegen.meta.CodegenDto
+import zygarde.codegen.meta.CodegenSealedInterface
+import zygarde.codegen.meta.SealedSubtypeMapping
+
+class SealedInterfaceSpec(val name: String) {
+  var discriminatorProperty: String = "type"
+  private val _subtypes = mutableListOf<SealedSubtypeMapping>()
+
+  fun subtype(discriminatorValue: String, dto: CodegenDto) {
+    _subtypes.add(SealedSubtypeMapping(discriminatorValue, dto))
+  }
+
+  fun build() = CodegenSealedInterface(name, discriminatorProperty, _subtypes.toList())
+}

--- a/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/generator/DtoFieldMappingCodeGenerator.kt
+++ b/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/generator/DtoFieldMappingCodeGenerator.kt
@@ -2,6 +2,7 @@ package zygarde.codegen.dsl.generator
 
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
@@ -19,12 +20,16 @@ import zygarde.codegen.dsl.model.type.ForceNull
 import zygarde.codegen.dsl.model.type.ValueProviderParameterType
 import zygarde.codegen.extension.kotlinpoet.generic
 import zygarde.codegen.extension.kotlinpoet.kotlin
+import zygarde.codegen.meta.CodegenSealedInterface
 import zygarde.core.annotation.Comment
 import java.io.Serializable
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.memberProperties
 
-class DtoFieldMappingCodeGenerator(val dtoFieldMappings: Collection<DtoFieldMapping>) {
+class DtoFieldMappingCodeGenerator(
+  val dtoFieldMappings: Collection<DtoFieldMapping>,
+  val sealedInterfaces: Collection<CodegenSealedInterface> = emptyList(),
+) {
   val dtoPackageName = System.getProperty("zygarde.codegen.dsl.model-mapping.dto-package", "zygarde.codegen.data.dto")
   val modelExtensionPackageName = System.getProperty("zygarde.codegen.dsl.model-mapping.extension-package", "zygarde.codegen.model.extensions")
   var dtoToExtraToDtoMappingMap = dtoFieldMappings
@@ -35,11 +40,15 @@ class DtoFieldMappingCodeGenerator(val dtoFieldMappings: Collection<DtoFieldMapp
     .associate {
       it.key to it.value.groupBy { it.dto }
     }
+  val dtoToSealedInterface: Map<String, CodegenSealedInterface> = sealedInterfaces
+    .flatMap { sealed -> sealed.subtypes.map { it.dto.name to sealed } }
+    .toMap()
 
   fun generateFileSpec(): DtoFieldMappingGenerateResult {
     return DtoFieldMappingGenerateResult(
       dtoFileSpecs = listOf(
         generateDtos(),
+        generateSealedInterfaces(),
       ).flatten(),
       modelMappingFileSpecs = listOf(
         generateDtoExtraValue(),
@@ -155,6 +164,9 @@ $callDtoStatements
       dto.superInterfaces().forEach { i ->
         dtoClassBuilder.addSuperinterface(i)
       }
+      dtoToSealedInterface[dto.name]?.also { sealed ->
+        dtoClassBuilder.addSuperinterface(ClassName(dtoPackageName, sealed.name))
+      }
 
       dto.annotations().forEach { a ->
         dtoClassBuilder.addAnnotation(a)
@@ -220,6 +232,53 @@ $callDtoStatements
             .build()
         )
         .build()
+    }
+  }
+
+  private fun generateSealedInterfaces(): List<FileSpec> {
+    return sealedInterfaces.map { sealed ->
+      val sealedClassName = ClassName(dtoPackageName, sealed.name)
+      val fileBuilder = FileSpec.builder(dtoPackageName, sealed.name)
+      val interfaceBuilder = TypeSpec.interfaceBuilder(sealedClassName)
+        .addModifiers(KModifier.SEALED)
+
+      // @JsonTypeInfo
+      interfaceBuilder.addAnnotation(
+        AnnotationSpec.builder(ClassName("com.fasterxml.jackson.annotation", "JsonTypeInfo"))
+          .addMember("use = %T.%L", ClassName("com.fasterxml.jackson.annotation", "JsonTypeInfo", "Id"), "NAME")
+          .addMember("property = %S", sealed.discriminatorProperty)
+          .build()
+      )
+
+      // @JsonSubTypes
+      val jsonSubTypesBuilder = AnnotationSpec.builder(ClassName("com.fasterxml.jackson.annotation", "JsonSubTypes"))
+      val subtypeCodeBlock = CodeBlock.builder().add("value = [")
+      sealed.subtypes.forEachIndexed { idx, subtype ->
+        if (idx > 0) subtypeCodeBlock.add(", ")
+        subtypeCodeBlock.add(
+          "%T(value = %T::class, name = %S)",
+          ClassName("com.fasterxml.jackson.annotation", "JsonSubTypes", "Type"),
+          ClassName(dtoPackageName, subtype.dto.name),
+          subtype.discriminatorValue,
+        )
+      }
+      subtypeCodeBlock.add("]")
+      jsonSubTypesBuilder.addMember(subtypeCodeBlock.build())
+      interfaceBuilder.addAnnotation(jsonSubTypesBuilder.build())
+
+      // @Schema
+      val schemaBuilder = AnnotationSpec.builder(Schema::class)
+      val oneOfCodeBlock = CodeBlock.builder().add("oneOf = [")
+      sealed.subtypes.forEachIndexed { idx, subtype ->
+        if (idx > 0) oneOfCodeBlock.add(", ")
+        oneOfCodeBlock.add("%T::class", ClassName(dtoPackageName, subtype.dto.name))
+      }
+      oneOfCodeBlock.add("]")
+      schemaBuilder.addMember(oneOfCodeBlock.build())
+      schemaBuilder.addMember("discriminatorProperty = %S", sealed.discriminatorProperty)
+      interfaceBuilder.addAnnotation(schemaBuilder.build())
+
+      fileBuilder.addType(interfaceBuilder.build()).build()
     }
   }
 

--- a/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/main/kotlin/zygarde/codegen/meta/CodegenSealedInterface.kt
+++ b/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/main/kotlin/zygarde/codegen/meta/CodegenSealedInterface.kt
@@ -1,0 +1,12 @@
+package zygarde.codegen.meta
+
+data class CodegenSealedInterface(
+  val name: String,
+  val discriminatorProperty: String = "type",
+  val subtypes: List<SealedSubtypeMapping> = emptyList(),
+)
+
+data class SealedSubtypeMapping(
+  val discriminatorValue: String,
+  val dto: CodegenDto,
+)

--- a/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/test/kotlin/zygarde/codegen/dsl/SealedInterfaceSpecTest.kt
+++ b/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/test/kotlin/zygarde/codegen/dsl/SealedInterfaceSpecTest.kt
@@ -1,0 +1,38 @@
+package zygarde.codegen.dsl
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import zygarde.codegen.meta.CodegenDtoSimple
+
+class SealedInterfaceSpecTest {
+  enum class TestDtos : CodegenDtoSimple {
+    FooDto,
+    BarDto,
+  }
+
+  @Test
+  fun `should build sealed interface with default discriminator`() {
+    val spec = SealedInterfaceSpec("MyResult")
+    spec.subtype("foo", TestDtos.FooDto)
+    spec.subtype("bar", TestDtos.BarDto)
+    val result = spec.build()
+
+    result.name shouldBe "MyResult"
+    result.discriminatorProperty shouldBe "type"
+    result.subtypes.size shouldBe 2
+    result.subtypes[0].discriminatorValue shouldBe "foo"
+    result.subtypes[0].dto shouldBe TestDtos.FooDto
+    result.subtypes[1].discriminatorValue shouldBe "bar"
+    result.subtypes[1].dto shouldBe TestDtos.BarDto
+  }
+
+  @Test
+  fun `should build sealed interface with custom discriminator`() {
+    val spec = SealedInterfaceSpec("MyResult")
+    spec.discriminatorProperty = "kind"
+    spec.subtype("a", TestDtos.FooDto)
+    val result = spec.build()
+
+    result.discriminatorProperty shouldBe "kind"
+  }
+}

--- a/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/test/kotlin/zygarde/codegen/dsl/generator/DtoFieldMappingCodeGeneratorSealedInterfaceTest.kt
+++ b/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/test/kotlin/zygarde/codegen/dsl/generator/DtoFieldMappingCodeGeneratorSealedInterfaceTest.kt
@@ -1,0 +1,67 @@
+package zygarde.codegen.dsl.generator
+
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Test
+import zygarde.codegen.meta.CodegenDtoSimple
+import zygarde.codegen.meta.CodegenSealedInterface
+import zygarde.codegen.meta.SealedSubtypeMapping
+
+class DtoFieldMappingCodeGeneratorSealedInterfaceTest {
+  enum class TestDtos : CodegenDtoSimple {
+    SuccessDto,
+    FailureDto,
+  }
+
+  @Test
+  fun `should generate sealed interface with Jackson and Schema annotations`() {
+    val sealed = CodegenSealedInterface(
+      name = "PaymentResult",
+      discriminatorProperty = "type",
+      subtypes = listOf(
+        SealedSubtypeMapping("success", TestDtos.SuccessDto),
+        SealedSubtypeMapping("failure", TestDtos.FailureDto),
+      ),
+    )
+
+    val result = DtoFieldMappingCodeGenerator(
+      dtoFieldMappings = emptyList(),
+      sealedInterfaces = listOf(sealed),
+    ).generateFileSpec()
+
+    val sealedFiles = result.dtoFileSpecs.filter { it.name == "PaymentResult" }
+    sealedFiles shouldHaveSize 1
+
+    val output = sealedFiles.first().toString()
+    output shouldContain "sealed interface PaymentResult"
+    output shouldContain "@JsonTypeInfo"
+    output shouldContain "JsonTypeInfo.Id.NAME"
+    output shouldContain """property = "type""""
+    output shouldContain "@JsonSubTypes"
+    output shouldContain """JsonSubTypes.Type(value = SuccessDto::class, name = "success")"""
+    output shouldContain """JsonSubTypes.Type(value = FailureDto::class, name = "failure")"""
+    output shouldContain "@Schema"
+    output shouldContain "oneOf = [SuccessDto::class, FailureDto::class]"
+    output shouldContain """discriminatorProperty = "type""""
+  }
+
+  @Test
+  fun `should add sealed interface as superinterface on subtype DTOs`() {
+    val sealed = CodegenSealedInterface(
+      name = "PaymentResult",
+      discriminatorProperty = "type",
+      subtypes = listOf(
+        SealedSubtypeMapping("success", TestDtos.SuccessDto),
+      ),
+    )
+
+    val generator = DtoFieldMappingCodeGenerator(
+      dtoFieldMappings = emptyList(),
+      sealedInterfaces = listOf(sealed),
+    )
+
+    generator.dtoToSealedInterface["SuccessDto"] shouldBe sealed
+    generator.dtoToSealedInterface["FailureDto"] shouldBe null
+  }
+}


### PR DESCRIPTION
Add sealedInterface() DSL function to ModelMappingCodegenSpec that generates Kotlin sealed interfaces with @JsonTypeInfo, @JsonSubTypes, and @Schema annotations for polymorphic API response types.