### PR TITLE
feat(model-mapping): use data object for sealed subtypes and support multiple sealed interfaces

### DIFF
--- a/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/generator/DtoFieldMappingCodeGenerator.kt
+++ b/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/generator/DtoFieldMappingCodeGenerator.kt
@@ -40,15 +40,16 @@ class DtoFieldMappingCodeGenerator(
     .associate {
       it.key to it.value.groupBy { it.dto }
     }
-  val dtoToSealedInterface: Map<String, CodegenSealedInterface> = sealedInterfaces
+  val dtoToSealedInterfaces: Map<String, List<CodegenSealedInterface>> = sealedInterfaces
     .flatMap { sealed -> sealed.subtypes.map { it.dto.name to sealed } }
-    .toMap()
+    .groupBy({ it.first }, { it.second })
 
   fun generateFileSpec(): DtoFieldMappingGenerateResult {
     return DtoFieldMappingGenerateResult(
       dtoFileSpecs = listOf(
         generateDtos(),
         generateSealedInterfaces(),
+        generateObjectSubtypes(),
       ).flatten(),
       modelMappingFileSpecs = listOf(
         generateDtoExtraValue(),
@@ -164,7 +165,7 @@ $callDtoStatements
       dto.superInterfaces().forEach { i ->
         dtoClassBuilder.addSuperinterface(i)
       }
-      dtoToSealedInterface[dto.name]?.also { sealed ->
+      dtoToSealedInterfaces[dto.name]?.forEach { sealed ->
         dtoClassBuilder.addSuperinterface(ClassName(dtoPackageName, sealed.name))
       }
 
@@ -280,6 +281,24 @@ $callDtoStatements
 
       fileBuilder.addType(interfaceBuilder.build()).build()
     }
+  }
+
+  private fun generateObjectSubtypes(): List<FileSpec> {
+    val dtosWithMappings = dtoFieldMappings.map { it.dto.name }.toSet()
+    return dtoToSealedInterfaces
+      .filterKeys { it !in dtosWithMappings }
+      .map { (dtoName, sealedList) ->
+        val dtoClassName = ClassName(dtoPackageName, dtoName)
+        val fileBuilder = FileSpec.builder(dtoPackageName, dtoName)
+        val objectBuilder = TypeSpec.objectBuilder(dtoClassName)
+          .addModifiers(KModifier.DATA)
+          .addAnnotation(Schema::class)
+          .addSuperinterface(Serializable::class)
+        sealedList.forEach { sealed ->
+          objectBuilder.addSuperinterface(ClassName(dtoPackageName, sealed.name))
+        }
+        fileBuilder.addType(objectBuilder.build()).build()
+      }
   }
 
   private fun generateDtoExtraValue(): List<FileSpec> {

--- a/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/test/kotlin/zygarde/codegen/dsl/generator/DtoFieldMappingCodeGeneratorSealedInterfaceTest.kt
+++ b/modules-model-mapping/zygarde-model-mapping-codegen-dsl/src/test/kotlin/zygarde/codegen/dsl/generator/DtoFieldMappingCodeGeneratorSealedInterfaceTest.kt
@@ -61,7 +61,60 @@ class DtoFieldMappingCodeGeneratorSealedInterfaceTest {
       sealedInterfaces = listOf(sealed),
     )
 
-    generator.dtoToSealedInterface["SuccessDto"] shouldBe sealed
-    generator.dtoToSealedInterface["FailureDto"] shouldBe null
+    generator.dtoToSealedInterfaces["SuccessDto"] shouldBe listOf(sealed)
+    generator.dtoToSealedInterfaces["FailureDto"] shouldBe null
+  }
+
+  @Test
+  fun `should generate data object subtype for sealed interface when dto has no field mappings`() {
+    val sealed = CodegenSealedInterface(
+      name = "PaymentResult",
+      discriminatorProperty = "type",
+      subtypes = listOf(
+        SealedSubtypeMapping("success", TestDtos.SuccessDto),
+        SealedSubtypeMapping("failure", TestDtos.FailureDto),
+      ),
+    )
+
+    val result = DtoFieldMappingCodeGenerator(
+      dtoFieldMappings = emptyList(),
+      sealedInterfaces = listOf(sealed),
+    ).generateFileSpec()
+
+    val successFile = result.dtoFileSpecs.first { it.name == "SuccessDto" }
+    val successOutput = successFile.toString()
+    successOutput shouldContain "data object SuccessDto"
+    successOutput shouldContain "Serializable"
+    successOutput shouldContain "PaymentResult"
+
+    val failureFile = result.dtoFileSpecs.first { it.name == "FailureDto" }
+    val failureOutput = failureFile.toString()
+    failureOutput shouldContain "data object FailureDto"
+    failureOutput shouldContain "Serializable"
+    failureOutput shouldContain "PaymentResult"
+  }
+
+  @Test
+  fun `should support dto as subtype of multiple sealed interfaces`() {
+    val sealedA = CodegenSealedInterface(
+      name = "ResultA",
+      subtypes = listOf(SealedSubtypeMapping("shared", TestDtos.SuccessDto)),
+    )
+    val sealedB = CodegenSealedInterface(
+      name = "ResultB",
+      subtypes = listOf(SealedSubtypeMapping("shared", TestDtos.SuccessDto)),
+    )
+
+    val result = DtoFieldMappingCodeGenerator(
+      dtoFieldMappings = emptyList(),
+      sealedInterfaces = listOf(sealedA, sealedB),
+    ).generateFileSpec()
+
+    val objectFiles = result.dtoFileSpecs.filter { it.name == "SuccessDto" }
+    objectFiles shouldHaveSize 1
+
+    val output = objectFiles.first().toString()
+    output shouldContain "ResultA"
+    output shouldContain "ResultB"
   }
 }


### PR DESCRIPTION
- Generate `data object` instead of `object` for sealed interface subtypes without field mappings (Kotlin 1.9+)
- Fix dtoToSealedInterface using toMap() which silently drops duplicates; now uses groupBy to allow a DTO to implement multiple sealed interfaces
- Prevent duplicate file generation when a DTO belongs to multiple sealed interfaces