### PR TITLE
fix(jpa): prevent KotlinPoet from wrapping between .let and { in DAO …

### DIFF
--- a/modules-jpa/zygarde-jpa-codegen-ksp/src/main/kotlin/zygarde/codegen/ksp/generator/ZygardeJpaDaoKspGenerator.kt
+++ b/modules-jpa/zygarde-jpa-codegen-ksp/src/main/kotlin/zygarde/codegen/ksp/generator/ZygardeJpaDaoKspGenerator.kt
@@ -245,7 +245,7 @@ class ZygardeJpaDaoKspGenerator(
           .build()
       )
       if (field.nullable) {
-        convenienceThisArgs.add(CodeBlock.of("${field.name} = ${field.name}?.let { listOf(it) }"))
+        convenienceThisArgs.add(CodeBlock.of("${field.name} = ${field.name}?.let·{ listOf(it) }"))
       } else {
         convenienceThisArgs.add(CodeBlock.of("${field.name} = listOf(${field.name})"))
       }
@@ -309,7 +309,7 @@ class ZygardeJpaDaoKspGenerator(
             buildScopedSearchBody(
               entityType,
               scopeFields,
-              "sorts?.let { findAll(%T.buildSpec(searchContent), it.%M()) } ?: findAll(%T.buildSpec(searchContent))",
+              "sorts?.let·{ findAll(%T.buildSpec(searchContent), it.%M()) } ?: findAll(%T.buildSpec(searchContent))",
               SearchSpecBuilder::class,
               toSpringDataSort,
               SearchSpecBuilder::class,
@@ -357,7 +357,7 @@ class ZygardeJpaDaoKspGenerator(
             buildScopedSearchBody(
               entityType,
               scopeFields,
-              "findOne(%T.buildSpec(searchContent)).let { if (it.isPresent) it.get() else null }",
+              "findOne(%T.buildSpec(searchContent)).let·{ if (it.isPresent) it.get() else null }",
               SearchSpecBuilder::class,
             )
           )
@@ -427,7 +427,7 @@ class ZygardeJpaDaoKspGenerator(
             .addParameter("searchContent", searchContentType)
             .returns(List::class.asClassName().parameterizedBy(entityType))
             .addStatement(
-              "return sorts?.let { findAll(%T.buildSpec(searchContent), it.%M()) } ?: search(searchContent)",
+              "return sorts?.let·{ findAll(%T.buildSpec(searchContent), it.%M()) } ?: search(searchContent)",
               SearchSpecBuilder::class,
               toSpringDataSort,
             )
@@ -460,7 +460,7 @@ class ZygardeJpaDaoKspGenerator(
             .addParameter("searchContent", searchContentType)
             .returns(entityType.copy(nullable = true))
             .addStatement(
-              "return findOne(%T.buildSpec(searchContent)).let { if (it.isPresent) it.get() else null }",
+              "return findOne(%T.buildSpec(searchContent)).let·{ if (it.isPresent) it.get() else null }",
               SearchSpecBuilder::class,
             )
             .build()
@@ -523,7 +523,7 @@ class ZygardeJpaDaoKspGenerator(
     scopeFields.forEach { field ->
       if (field.nullEquivalent != null) {
         if (field.nullable) {
-          builder.beginControlFlow("scope.${field.name}?.let { scopeValues ->")
+          builder.beginControlFlow("scope.${field.name}?.let·{ scopeValues ->")
           builder.beginControlFlow("if (scopeValues.any { it.toString() == %S })", field.nullEquivalent)
           builder.beginControlFlow("or")
           builder.addStatement("field<%T>(%S) inList scopeValues", field.typeName, field.name)
@@ -534,7 +534,7 @@ class ZygardeJpaDaoKspGenerator(
           builder.endControlFlow()
           builder.endControlFlow()
         } else {
-          builder.beginControlFlow("scope.${field.name}.let { scopeValues ->")
+          builder.beginControlFlow("scope.${field.name}.let·{ scopeValues ->")
           builder.beginControlFlow("if (scopeValues.any { it.toString() == %S })", field.nullEquivalent)
           builder.beginControlFlow("or")
           builder.addStatement("field<%T>(%S) inList scopeValues", field.typeName, field.name)
@@ -546,7 +546,7 @@ class ZygardeJpaDaoKspGenerator(
           builder.endControlFlow()
         }
       } else if (field.nullable) {
-        builder.addStatement("scope.${field.name}?.let { field<%T>(%S) inList it }", field.typeName, field.name)
+        builder.addStatement("scope.${field.name}?.let·{ field<%T>(%S) inList it }", field.typeName, field.name)
       } else {
         builder.addStatement("field<%T>(%S) inList scope.${field.name}", field.typeName, field.name)
       }

--- a/modules-jpa/zygarde-jpa-codegen-ksp/src/test/resources/codegen/jpa/TestGenerateDao.kt
+++ b/modules-jpa/zygarde-jpa-codegen-ksp/src/test/resources/codegen/jpa/TestGenerateDao.kt
@@ -52,3 +52,16 @@ class IdClassBook(
 class SequenceBook(
   var name: String = ""
 ) : SequenceIntIdEntity()
+
+/**
+ * Regression fixture for KotlinPoet line-wrapping in generated DAO extensions.
+ * The long class name forces the generated `search(sorts, searchContent)` body
+ * past KotlinPoet's default wrap column so any wrap between `.let` and `{`
+ * would break compilation of the generated file.
+ */
+@ZyModel
+@Entity
+class VeryLongEntityNameForceWrapRegressionBookForDaoExtensions(
+  @Id
+  var id: Long
+)

--- a/modules-jpa/zygarde-jpa-codegen-ksp/src/test/resources/codegen/jpa/TestGenerateScopedQuery.kt
+++ b/modules-jpa/zygarde-jpa-codegen-ksp/src/test/resources/codegen/jpa/TestGenerateScopedQuery.kt
@@ -84,3 +84,16 @@ class UnscopedByEmptyMarker(
   @Id
   var id: Long,
 ) : EmptyScopeMarker
+
+/**
+ * Regression fixture: long class name forces KotlinPoet to wrap the generated
+ * scoped sorted-search body. A wrap between `.let` and `{` would break the
+ * generated file compilation.
+ */
+@ZyModel
+@Entity
+class VeryLongEntityNameScopedRegressionEntityForDaoExtensions(
+  @Id
+  var id: Long,
+  override val regionId: Long = 0,
+) : RegionScoped

--- a/modules-jpa/zygarde-jpa-codegen/src/main/kotlin/zygarde/codegen/generator/impl/ZygardeJpaDaoGenerator.kt
+++ b/modules-jpa/zygarde-jpa-codegen/src/main/kotlin/zygarde/codegen/generator/impl/ZygardeJpaDaoGenerator.kt
@@ -244,7 +244,7 @@ class ZygardeJpaDaoGenerator(
           .build()
       )
       if (field.nullable) {
-        convenienceThisArgs.add(CodeBlock.of("${field.name} = ${field.name}?.let { listOf(it) }"))
+        convenienceThisArgs.add(CodeBlock.of("${field.name} = ${field.name}?.let·{ listOf(it) }"))
       } else {
         convenienceThisArgs.add(CodeBlock.of("${field.name} = listOf(${field.name})"))
       }
@@ -309,7 +309,7 @@ class ZygardeJpaDaoGenerator(
             buildScopedSearchBody(
               entityType,
               scopeFields,
-              "sorts?.let { findAll(%T.buildSpec(searchContent), it.%M()) } ?: findAll(%T.buildSpec(searchContent))",
+              "sorts?.let·{ findAll(%T.buildSpec(searchContent), it.%M()) } ?: findAll(%T.buildSpec(searchContent))",
               SearchSpecBuilder::class,
               toSpringDataSort,
               SearchSpecBuilder::class,
@@ -357,7 +357,7 @@ class ZygardeJpaDaoGenerator(
             buildScopedSearchBody(
               entityType,
               scopeFields,
-              "findOne(%T.buildSpec(searchContent)).let { if (it.isPresent) it.get() else null }",
+              "findOne(%T.buildSpec(searchContent)).let·{ if (it.isPresent) it.get() else null }",
               SearchSpecBuilder::class,
             )
           )
@@ -428,7 +428,7 @@ class ZygardeJpaDaoGenerator(
             .addParameter("searchContent", searchContentType)
             .returns(List::class.asClassName().parameterizedBy(entityType))
             .addStatement(
-              "return sorts?.let { findAll(%T.buildSpec(searchContent), it.%M()) } ?: search(searchContent)",
+              "return sorts?.let·{ findAll(%T.buildSpec(searchContent), it.%M()) } ?: search(searchContent)",
               SearchSpecBuilder::class,
               toSpringDataSort,
             )
@@ -461,7 +461,7 @@ class ZygardeJpaDaoGenerator(
             .addParameter("searchContent", searchContentType)
             .returns(entityType.copy(nullable = true))
             .addStatement(
-              "return findOne(%T.buildSpec(searchContent)).let { if (it.isPresent) it.get() else null }",
+              "return findOne(%T.buildSpec(searchContent)).let·{ if (it.isPresent) it.get() else null }",
               SearchSpecBuilder::class,
             )
             .build()
@@ -539,7 +539,7 @@ class ZygardeJpaDaoGenerator(
       if (field.nullEquivalent != null) {
         // NullEquivalent field: generate OR IS NULL when null-equivalent value is present
         if (field.nullable) {
-          builder.beginControlFlow("scope.${field.name}?.let { scopeValues ->")
+          builder.beginControlFlow("scope.${field.name}?.let·{ scopeValues ->")
           builder.beginControlFlow("if (scopeValues.any { it.toString() == %S })", field.nullEquivalent)
           builder.beginControlFlow("or")
           builder.addStatement("field<%T>(%S) inList scopeValues", field.typeName, field.name)
@@ -550,7 +550,7 @@ class ZygardeJpaDaoGenerator(
           builder.endControlFlow()
           builder.endControlFlow()
         } else {
-          builder.beginControlFlow("scope.${field.name}.let { scopeValues ->")
+          builder.beginControlFlow("scope.${field.name}.let·{ scopeValues ->")
           builder.beginControlFlow("if (scopeValues.any { it.toString() == %S })", field.nullEquivalent)
           builder.beginControlFlow("or")
           builder.addStatement("field<%T>(%S) inList scopeValues", field.typeName, field.name)
@@ -562,7 +562,7 @@ class ZygardeJpaDaoGenerator(
           builder.endControlFlow()
         }
       } else if (field.nullable) {
-        builder.addStatement("scope.${field.name}?.let { field<%T>(%S) inList it }", field.typeName, field.name)
+        builder.addStatement("scope.${field.name}?.let·{ field<%T>(%S) inList it }", field.typeName, field.name)
       } else {
         builder.addStatement("field<%T>(%S) inList scope.${field.name}", field.typeName, field.name)
       }

--- a/modules-jpa/zygarde-jpa-codegen/src/test/resources/codegen/jpa/TestGenerateDao.kt
+++ b/modules-jpa/zygarde-jpa-codegen/src/test/resources/codegen/jpa/TestGenerateDao.kt
@@ -52,3 +52,16 @@ class IdClassBook(
 class SequenceBook(
   var name: String = ""
 ) : SequenceIntIdEntity()
+
+/**
+ * Regression fixture for KotlinPoet line-wrapping in generated DAO extensions.
+ * The long class name forces the generated `search(sorts, searchContent)` body
+ * past KotlinPoet's default wrap column so any wrap between `.let` and `{`
+ * would break compilation of the generated file.
+ */
+@ZyModel
+@Entity
+class VeryLongEntityNameForceWrapRegressionBookForDaoExtensions(
+  @Id
+  var id: Long
+)

--- a/modules-jpa/zygarde-jpa-codegen/src/test/resources/codegen/jpa/TestGenerateScopedQuery.kt
+++ b/modules-jpa/zygarde-jpa-codegen/src/test/resources/codegen/jpa/TestGenerateScopedQuery.kt
@@ -84,3 +84,16 @@ class UnscopedByEmptyMarker(
   @Id
   var id: Long,
 ) : EmptyScopeMarker
+
+/**
+ * Regression fixture: long class name forces KotlinPoet to wrap the generated
+ * scoped sorted-search body. A wrap between `.let` and `{` would break the
+ * generated file compilation.
+ */
+@ZyModel
+@Entity
+class VeryLongEntityNameScopedRegressionEntityForDaoExtensions(
+  @Id
+  var id: Long,
+  override val regionId: Long = 0,
+) : RegionScoped


### PR DESCRIPTION
…extensions

KotlinPoet wraps addStatement templates at any space, so entities with long class names produced broken DAO extensions like:

    = sorts?.let
      { findAll(...) } ?: search(...)

Kotlin parses `sorts?.let` as a complete expression, then treats the `{ ... }` on the next line as an anonymous top-level function — causing "Expecting a top level declaration", "Unresolved reference: findAll/it/ searchContent", and "Conflicting overloads" errors across every generated *DaoExtensions.kt whose entity name pushed the body past the wrap column.

Insert KotlinPoet non-breaking spaces (·, U+00B7) between `.let` and `{` in every generator template that emits a lambda, covering both KAPT and KSP generators plus the scope data class convenience constructor.

Regression fixtures: long-named entities added to TestGenerateDao.kt and TestGenerateScopedQuery.kt so the existing compile-the-generated-output assertions catch this class of wrap bug in future.