### PR TITLE
feat(jpa): strengthen scoped queries

### DIFF
--- a/doc/scoped-queries-guide.md
+++ b/doc/scoped-queries-guide.md
@@ -1,6 +1,6 @@
 # ScopedQueries 使用教學
 
-這份說明整理了 `@ScopeMarker`、`@NullEquivalent` 與 codegen 生成 scoped DAO API 的使用方式，適合提供給下游專案或團隊成員快速上手。
+這份說明整理了 `@ScopeMarker`、`@ScopeOp`、`@NullEquivalent`、`ScopeFilter` 與 codegen 生成 scoped DAO API 的使用方式，適合提供給下游專案或團隊成員快速上手。
 
 > 本文對應目前主幹 (`v2`) 的實作；舊版 `scoped-queries-slack-guide.md` 描述的 fluent `dao.xxxScoped(scope)` 設計已被棄用，請以本文為準。
 
@@ -59,7 +59,31 @@ interface TenantScoped {
 
 一個 Entity 可以實作多個 `@ScopeMarker` interface，它們的 property 會被合併到同一個 `{Entity}Scope` 裡。
 
-### 2. `@NullEquivalent`
+### 2. `@ScopeOp`
+
+`@get:ScopeOp` 用來選擇 scope property 產生的 predicate；未標註時預設為 `IN`。
+
+```kotlin
+@ScopeMarker
+interface OrderScoped {
+  val status: OrderStatus
+
+  @get:ScopeOp(ScopeOperator.NOT_IN)
+  val excludedStatus: OrderStatus
+
+  @get:ScopeOp(ScopeOperator.IS_NOT_NULL)
+  val demandLinked: Boolean
+}
+```
+
+| Operator | Generated scope value | `true`／values 的效果 | `false`／`null` 的效果 |
+| --- | --- | --- | --- |
+| `IN` | `ScopeFilter<T>` | 欄位值包含在集合內 | `All` 或 optional `null` 略過 |
+| `NOT_IN` | `ScopeFilter<T>` | 排除集合中的欄位值 | `All` 或 optional `null` 略過 |
+| `IS_NULL` | `Boolean` | `IS NULL` | 略過 |
+| `IS_NOT_NULL` | `Boolean` | `IS NOT NULL` | 略過 |
+
+### 3. `@NullEquivalent`
 
 `@NullEquivalent("SENTINEL")` 標在 scope interface 的 property getter 上，代表「這個值等同於 NULL，查詢時要額外 OR IS NULL」。
 
@@ -84,30 +108,43 @@ visibility IN (...) OR visibility IS NULL
 
 value class、data class、或自定義 `toString()` 的型別會安靜地錯過 sentinel，不會觸發 `OR IS NULL`。
 
-### 3. Generated `{Entity}Scope` data class
+`@NullEquivalent` 只影響 `IN` 和 `NOT_IN`。搭配 `NOT_IN` 時：
+
+- 排除集合包含 sentinel：生成 `NOT IN (...) AND IS NOT NULL`，SQL NULL 也被排除。
+- 排除集合不含 sentinel：生成 `NOT IN (...) OR IS NULL`，SQL NULL 保持包含。
+
+### 4. Generated `{Entity}Scope` data class
 
 只要 Entity 實作任何有 property 的 `@ScopeMarker` interface，codegen 就會在 DAO 所在 package 產出一個 `{Entity}Scope` data class：
 
 ```kotlin
 // Generated: NoteScope.kt
 public data class NoteScope(
-  public val tenantId: Collection<String>,
-  public val visibility: Collection<String>? = null,
+  public val tenantId: ScopeFilter<String>,
+  public val visibility: ScopeFilter<String> = ScopeFilter.All,
 ) {
+  public constructor(tenantId: Collection<String>, visibility: Collection<String>? = null) : this(
+    tenantId = ScopeFilter.Of(tenantId),
+    visibility = visibility?.let { ScopeFilter.Of(it) } ?: ScopeFilter.All,
+  )
+
   public constructor(tenantId: String, visibility: String? = null) : this(
-    tenantId = listOf(tenantId),
-    visibility = visibility?.let { listOf(it) },
+    tenantId = ScopeFilter.Of(listOf(tenantId)),
+    visibility = visibility?.let { ScopeFilter.Of(listOf(it)) } ?: ScopeFilter.All,
   )
 }
 ```
 
 重點：
 
-- 每個 scope 欄位都是 `Collection<T>`，支援多值 `IN` 查詢
-- 可為 null 的欄位會變成 `Collection<T>?` 並預設 `null`（= 不加條件）
-- 自動附上「單值」便利 constructor
+- Membership 欄位使用 `ScopeFilter<T>`，明確區分「略過」與「使用集合篩選」
+- `ScopeFilter.All` 明確略過該欄位的 predicate
+- `ScopeFilter.Of(values)` 使用集合篩選；空集合刻意 match nothing
+- Entity property 可為 null 時，對應 membership scope 欄位預設 `ScopeFilter.All`，代表略過該欄位；`IS_NULL`／`IS_NOT_NULL` 的 Boolean 欄位仍以 `null` 略過
+- 仍附上接受 `Collection<T>` 與單一 `T` 的 compatibility constructors
+- nullable membership 的 literal `null` 會明確解析到 collection compatibility constructor，並轉成 `ScopeFilter.All`；`Scope()`、`Scope(field = null)` 與 `Scope(null)` 都不會產生 overload ambiguity
 
-### 4. Generated scoped DAO extensions
+### 5. Generated scoped DAO extensions
 
 同時會產出一份 `{Entity}DaoExtensions.kt`，提供以下 **top-level extension functions**：
 
@@ -124,7 +161,7 @@ fun NoteDao.searchPage(scope: NoteScope, req: PagingAndSortingRequest, searchCon
 fun NoteDao.remove(scope: NoteScope, searchContent: EnhancedSearch<Note>.() -> Unit = {}): Int
 ```
 
-注意：**沒有**不帶 scope 的 `search(...)` overload — 這就是「強制」的本質。
+不帶 scope 的同名函式只會生成 `DeprecationLevel.ERROR` placeholder，用來讓 compiler 顯示具體的 scope 類別與 `ScopeFilter.All` 修法；其函式內容也會直接 `error(...)`，不會執行 unscoped query。
 
 ## 一般使用流程
 
@@ -204,7 +241,12 @@ noteDao.search(
 noteDao.search { title() like "%$keyword%" }
 ```
 
-會編譯失敗 — generator 沒有產出不帶 scope 的 overload。
+會編譯失敗，並收到類似以下的指引：
+
+```text
+此實體已啟用 ScopedQueries：請以第一參數傳入 NoteScope
+（全放行請顯式傳 NoteScope(tenantId = ScopeFilter.All)）
+```
 
 **傳錯 scope 類別不能編譯：**
 
@@ -222,29 +264,34 @@ productDao.search(ProductScope(...))  // ProductScope 根本不存在
 
 如果 `Product` 沒實作任何 `@ScopeMarker` interface，`ProductScope` 不會被生成，直接 unresolved reference。
 
-### 框架無法保證的情況
+### 安全邊界與框架無法保證的情況
 
-`JpaSpecificationExecutor<T>` 的原生 `findAll(spec)` 仍然可呼叫。如果團隊要完全封掉繞路寫法，請在 code review 或 detekt 自定規則中補一層規範。
+ScopedQueries 的 compiler 保證只涵蓋 generated `search`／`searchOne`／`searchCount`／`searchPage`／`remove` extensions。
+DAO 仍繼承的 Spring Data API（例如 `JpaSpecificationExecutor<T>.findAll(spec)`、`findOne(spec)`）可以直接呼叫，
+`ScopeFilter.All` 也能刻意略過 predicate。因此 ScopedQueries **不是 authorization 或資料隔離的安全邊界**。
+
+這項限制是刻意保留的架構邊界：generator 不會移除 Spring Data API，也不會改寫 `ZygardeEnhancedDao` 的
+`select`／`selectOne`。若 scope 涉及租戶隔離或存取控制，請另外以 service/repository facade 限制 DAO 暴露面，
+並依團隊需求用 code review 或 detekt 自定規則阻止直接呼叫原生 API；不要只依賴 generated extension signature。
 
 ## 執行時重要細節
 
-### 空 Collection 等於「不加條件」
+### Scope 的空 Collection 會 match nothing
 
-Zygarde 的 `ConditionActionImpl.inList` 對空集合會 **silently skip**，不會產出 `WHERE field IN ()`：
+Scope compatibility constructor 會把 collection 包成 `ScopeFilter.Of(values)`。空集合因此是明確的「沒有任何允許值」，結果為零筆：
 
 ```kotlin
 noteDao.search(NoteScope(tenantId = emptyList()))
-// → 回傳所有 Note，而非 0 筆
+// → 0 筆
 ```
 
-如果呼叫端需要「空集合就回傳 0 筆」的語意，必須自行在呼叫前檢查：
+需要刻意略過某個 scope predicate 時，必須顯式使用 `ScopeFilter.All`：
 
 ```kotlin
-if (tenantIds.isEmpty()) return emptyList()
-noteDao.search(NoteScope(tenantId = tenantIds))
+noteDao.search(NoteScope(tenantId = ScopeFilter.All))
 ```
 
-這個行為是 DSL 層的既有約定，scope 沿用同一個 inList，所以也繼承這個陷阱。測試 `NoteScopedQueryTest` 有一個 case 把這個不變量 lock 住。
+一般 search DSL 的既有 `inList(emptyList())` 仍會略過條件，沒有改變。若一般 DSL 的空集合也應 match nothing，請改用 `inListStrict(values)`；兩者傳入 `null` 時都會略過條件。
 
 ### `@NullEquivalent` 必須是 String 或 default-toString Enum
 
@@ -275,7 +322,7 @@ interface CurrencyScoped {
 
 Sample 專案：
 
-- `samples/todo-legacy` — KAPT 範例
+- `samples/todo-legacy` — KAPT 範例 + `@DataJpaTest`／H2 scoped runtime smoke test
 - `samples/todo-ksp` — KSP 範例 + `@DataJpaTest` 整合測試（`NoteScopedQueryTest`）
 
 同一份 marker interface + entity 在兩邊的生成結果是等價的；專案可以只選其中一邊接入。
@@ -298,7 +345,8 @@ object NoteScopes {
 }
 ```
 
-- 呼叫端必須先檢查空集合再傳進 scope，避免誤判為 no-filter
+- 不要以空集合表示全放行；scope 必須使用 `ScopeFilter.All` 明確表達
+- 一般 DSL 對使用者輸入集合需要「空集合＝零筆」時使用 `inListStrict`
 - `@NullEquivalent` 欄位一律用 `String` 或 default-toString `Enum`
 
 ## 最推薦的實作範例
@@ -350,7 +398,9 @@ noteDao.searchOneOrThrow(NoteScope(tenantId = "t1"), NoteError.NOT_FOUND) {
 
 - 把 scope 條件從查詢細節抽離成共用資料結構
 - 用 codegen 產生一致的 scoped API，不需手刻
-- 利用「只生成帶 scope 的 overload」讓 compiler 直接擋下漏傳 scope 的寫法
+- 利用 scoped overload 與 error-deprecated placeholder，讓 compiler 直接擋下漏傳 scope 並提供修法
+- 用 `ScopeFilter.All`／`Of` 區分顯式全放行、正常集合與空集合
+- 以 `ScopeOp` 表達 `IN`、`NOT_IN`、`IS_NULL`、`IS_NOT_NULL`
 - `@NullEquivalent` 處理 sentinel ↔ NULL 的常見模式
 
 如果你的專案有類似：

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,11 +15,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added SQL API documentation covering query, command, pagination, parameter sources, context resolvers, and code generation properties.
 - Comprehensive documentation site with MkDocs Material
 - Automated documentation deployment via GitHub Actions
+- Scoped query fields now use `ScopeFilter`: `All` explicitly skips a predicate, while `Of(values)` applies one.
+- Scoped query properties support `IN`, `NOT_IN`, `IS_NULL`, and `IS_NOT_NULL` through `@get:ScopeOp`.
+- `inListStrict` preserves the existing null behavior while making an empty collection match nothing.
+- Missing-scope DAO calls now resolve to error-deprecated placeholders with an entity-specific migration hint.
 
 ### Changed
 - SQL API generated contracts now keep context parameters out of request DTOs, API interfaces, Feign interfaces, controllers, and service interfaces.
 - SQL API validation now accepts context parameters in main SQL and paged count SQL while still rejecting unused declarations.
 - Improved documentation structure and organization
+- **Generated ScopedQueries API and ABI:** membership properties changed from `Collection<T>` to `ScopeFilter<T>`.
+  This changes the primary constructor, property getters, data-class `componentN`, `copy`, and their JVM signatures;
+  regenerate scopes and recompile all consumers together. Existing scalar and collection constructor calls remain
+  source-compatible when their first membership field is supplied. If every membership field is optional,
+  compatibility constructors require that first field to avoid overload ambiguity. Replace an intentional empty-list
+  bypass with `ScopeFilter.All`; `ScopeFilter.Of(emptyList())` and compatibility constructors receiving an empty
+  collection now match nothing. Nullable membership properties are non-null `ScopeFilter<T>` values defaulting to
+  `ScopeFilter.All`; compatibility calls using a literal `null` resolve without constructor ambiguity and retain the
+  previous skip-predicate behavior.
+- Adding `inListStrict` expands the public `ConditionAction` API. It has a default implementation so direct
+  implementors remain source-compatible, but consumers and custom implementations should still be recompiled together.
 
 ### Fixed
 - Various documentation improvements and corrections

--- a/docs/guide/search-dsl.md
+++ b/docs/guide/search-dsl.md
@@ -58,6 +58,15 @@ bookDao.search {
 }
 ```
 
+`inList` treats both `null` and an empty collection as “do not add a predicate”. Use
+`inListStrict` when an empty user-supplied collection must match nothing:
+
+```kotlin
+bookDao.search {
+  status() inListStrict selectedStatuses // null skips; empty matches nothing
+}
+```
+
 ## String Operations
 
 ### Contains

--- a/modules-jpa/zygarde-jpa-codegen-ksp/src/main/kotlin/zygarde/codegen/ksp/generator/ZygardeJpaDaoKspGenerator.kt
+++ b/modules-jpa/zygarde-jpa-codegen-ksp/src/main/kotlin/zygarde/codegen/ksp/generator/ZygardeJpaDaoKspGenerator.kt
@@ -6,6 +6,7 @@ import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
@@ -14,6 +15,7 @@ import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
@@ -21,6 +23,7 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.UNIT
 import com.squareup.kotlinpoet.asClassName
+import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
 import org.springframework.beans.factory.annotation.Autowired
@@ -29,6 +32,7 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.stereotype.Component
+import zygarde.codegen.ScopeOperator
 import zygarde.codegen.ksp.ZygardeJpaKspOptions.BASE_PACKAGE
 import zygarde.codegen.ksp.ZygardeJpaKspOptions.DAO_COMBINE
 import zygarde.codegen.ksp.ZygardeJpaKspOptions.DAO_INHERIT
@@ -43,6 +47,7 @@ import zygarde.data.api.PagingAndSortingRequest
 import zygarde.data.api.SortField
 import zygarde.data.jpa.search.EnhancedSearch
 import zygarde.data.jpa.search.SearchSpecBuilder
+import zygarde.data.jpa.search.ScopeFilter
 
 class ZygardeJpaDaoKspGenerator(
   private val codeGenerator: CodeGenerator,
@@ -161,6 +166,7 @@ class ZygardeJpaDaoKspGenerator(
     val typeName: TypeName,
     val nullable: Boolean,
     val nullEquivalent: String?,
+    val operator: ScopeOperator,
   )
 
   private fun collectScopeFields(element: KSClassDeclaration): List<ScopeFieldInfo> {
@@ -185,21 +191,28 @@ class ZygardeJpaDaoKspGenerator(
             val propName = prop.simpleName.asString()
             val propType = prop.type.resolve()
             val isNullable = propType.isMarkedNullable
-            val nullEquivalentAnnotation = prop.annotations.find {
-              it.shortName.asString() == "NullEquivalent"
-            } ?: prop.getter?.annotations?.find {
+            val nullEquivalentAnnotation = prop.getter?.annotations?.find {
               it.shortName.asString() == "NullEquivalent"
             }
             val nullEquivalent = nullEquivalentAnnotation
               ?.arguments?.find { it.name?.asString() == "value" }?.value as? String
+            val scopeOpAnnotation = prop.getter?.annotations?.find {
+              it.shortName.asString() == "ScopeOp"
+            }
+            val operator = scopeOpAnnotation
+              ?.arguments?.find { it.name?.asString() == "value" }
+              ?.value?.toString()?.substringAfterLast('.')?.let(ScopeOperator::valueOf)
+              ?: ScopeOperator.IN
+            val isMembership = operator == ScopeOperator.IN || operator == ScopeOperator.NOT_IN
             val typeName = propType.toTypeName().copy(nullable = false)
             result.putIfAbsent(
               propName,
               ScopeFieldInfo(
                 name = propName,
                 typeName = typeName,
-                nullable = isNullable || nullEquivalent != null,
-                nullEquivalent = nullEquivalent,
+                nullable = isNullable || (isMembership && nullEquivalent != null),
+                nullEquivalent = nullEquivalent.takeIf { isMembership },
+                operator = operator,
               )
             )
           }
@@ -217,16 +230,32 @@ class ZygardeJpaDaoKspGenerator(
   ) {
     val scopeClassName = "${entityName}Scope"
     val collectionType = Collection::class.asClassName()
+    val javaCollectionType = ClassName("java.util", "Collection")
+    val scopeFilterType = ScopeFilter::class.asClassName()
 
     val primaryConstructor = FunSpec.constructorBuilder()
     val properties = mutableListOf<PropertySpec>()
 
     fields.forEach { field ->
-      val collectionOfField = collectionType.parameterizedBy(field.typeName)
-      val paramType = if (field.nullable) collectionOfField.copy(nullable = true) else collectionOfField
+      val fieldScopeType = when (field.operator) {
+        ScopeOperator.IN, ScopeOperator.NOT_IN -> scopeFilterType.parameterizedBy(field.typeName)
+        ScopeOperator.IS_NULL, ScopeOperator.IS_NOT_NULL -> Boolean::class.asTypeName()
+      }
+      val paramType = when (field.operator) {
+        ScopeOperator.IN, ScopeOperator.NOT_IN -> fieldScopeType
+        ScopeOperator.IS_NULL, ScopeOperator.IS_NOT_NULL -> if (field.nullable) fieldScopeType.copy(nullable = true) else fieldScopeType
+      }
       primaryConstructor.addParameter(
         ParameterSpec.builder(field.name, paramType)
-          .also { if (field.nullable) it.defaultValue("null") }
+          .also {
+            if (field.nullable) {
+              if (field.operator == ScopeOperator.IN || field.operator == ScopeOperator.NOT_IN) {
+                it.defaultValue("%T.All", ScopeFilter::class)
+              } else {
+                it.defaultValue("null")
+              }
+            }
+          }
           .build()
       )
       properties.add(
@@ -236,28 +265,100 @@ class ZygardeJpaDaoKspGenerator(
       )
     }
 
+    val collectionConstructor = FunSpec.constructorBuilder()
+    val collectionThisArgs = mutableListOf<CodeBlock>()
+    val requiredCompatibilityField = fields
+      .filter { it.operator == ScopeOperator.IN || it.operator == ScopeOperator.NOT_IN }
+      .takeIf { membershipFields -> membershipFields.all { it.nullable } }
+      ?.firstOrNull()
+    fields.forEach { field ->
+      val baseType = when (field.operator) {
+        ScopeOperator.IN, ScopeOperator.NOT_IN -> collectionType.parameterizedBy(field.typeName)
+        ScopeOperator.IS_NULL, ScopeOperator.IS_NOT_NULL -> Boolean::class.asTypeName()
+      }
+      val paramType = if (field.nullable) baseType.copy(nullable = true) else baseType
+      collectionConstructor.addParameter(
+        ParameterSpec.builder(field.name, paramType)
+          .also { if (field.nullable && field != requiredCompatibilityField) it.defaultValue("null") }
+          .build()
+      )
+      when (field.operator) {
+        ScopeOperator.IN, ScopeOperator.NOT_IN -> if (field.nullable) {
+          collectionThisArgs.add(
+            CodeBlock.of("${field.name} = ${field.name}?.let·{ %T.Of(it) } ?: %T.All", ScopeFilter::class, ScopeFilter::class)
+          )
+        } else {
+          collectionThisArgs.add(CodeBlock.of("${field.name} = %T.Of(${field.name})", ScopeFilter::class))
+        }
+        ScopeOperator.IS_NULL, ScopeOperator.IS_NOT_NULL -> {
+          collectionThisArgs.add(CodeBlock.of("${field.name} = ${field.name}"))
+        }
+      }
+    }
+    collectionConstructor.callThisConstructor(collectionThisArgs)
+
     val convenienceConstructor = FunSpec.constructorBuilder()
     val convenienceThisArgs = mutableListOf<CodeBlock>()
     fields.forEach { field ->
-      val singleType = if (field.nullable) field.typeName.copy(nullable = true) else field.typeName
+      val baseType = when (field.operator) {
+        ScopeOperator.IN, ScopeOperator.NOT_IN -> field.typeName
+        ScopeOperator.IS_NULL, ScopeOperator.IS_NOT_NULL -> Boolean::class.asTypeName()
+      }
+      val singleType = if (field.nullable && field != requiredCompatibilityField) baseType.copy(nullable = true) else baseType
       convenienceConstructor.addParameter(
         ParameterSpec.builder(field.name, singleType)
-          .also { if (field.nullable) it.defaultValue("null") }
+          .also { if (field.nullable && field != requiredCompatibilityField) it.defaultValue("null") }
           .build()
       )
-      if (field.nullable) {
-        convenienceThisArgs.add(CodeBlock.of("${field.name} = ${field.name}?.let·{ listOf(it) }"))
-      } else {
-        convenienceThisArgs.add(CodeBlock.of("${field.name} = listOf(${field.name})"))
+      when (field.operator) {
+        ScopeOperator.IN, ScopeOperator.NOT_IN -> if (field.nullable && field != requiredCompatibilityField) {
+          convenienceThisArgs.add(
+            CodeBlock.of("${field.name} = ${field.name}?.let·{ %T.Of(listOf(it)) } ?: %T.All", ScopeFilter::class, ScopeFilter::class)
+          )
+        } else {
+          convenienceThisArgs.add(CodeBlock.of("${field.name} = %T.Of(listOf(${field.name}))", ScopeFilter::class))
+        }
+        ScopeOperator.IS_NULL, ScopeOperator.IS_NOT_NULL -> {
+          convenienceThisArgs.add(CodeBlock.of("${field.name} = ${field.name}"))
+        }
       }
     }
     convenienceConstructor.callThisConstructor(convenienceThisArgs)
 
+    val hasMembershipField = fields.any { it.operator == ScopeOperator.IN || it.operator == ScopeOperator.NOT_IN }
+    val convenienceErasedTypes = fields.map { field ->
+      when (field.operator) {
+        ScopeOperator.IN, ScopeOperator.NOT_IN -> when (val type = field.typeName) {
+          is ClassName -> type
+          is ParameterizedTypeName -> type.rawType
+          else -> null
+        }
+        ScopeOperator.IS_NULL, ScopeOperator.IS_NOT_NULL -> Boolean::class.asClassName()
+      }
+    }
+    val convenienceCollidesWithPrimary = fields.zip(convenienceErasedTypes).all { (field, erasedType) ->
+      field.operator == ScopeOperator.IS_NULL ||
+        field.operator == ScopeOperator.IS_NOT_NULL ||
+        erasedType == scopeFilterType
+    }
+    val convenienceCollidesWithCollection = fields.zip(convenienceErasedTypes).all { (field, erasedType) ->
+      field.operator == ScopeOperator.IS_NULL ||
+        field.operator == ScopeOperator.IS_NOT_NULL ||
+        erasedType == collectionType ||
+        erasedType == javaCollectionType
+    }
     val typeSpec = TypeSpec.classBuilder(scopeClassName)
       .addModifiers(KModifier.DATA)
       .primaryConstructor(primaryConstructor.build())
       .addProperties(properties)
-      .addFunction(convenienceConstructor.build())
+      .also {
+        if (hasMembershipField) {
+          it.addFunction(collectionConstructor.build())
+          if (!convenienceCollidesWithPrimary && !convenienceCollidesWithCollection) {
+            it.addFunction(convenienceConstructor.build())
+          }
+        }
+      }
       .build()
 
     FileSpec.builder(daoPackage, scopeClassName)
@@ -418,6 +519,15 @@ class ZygardeJpaDaoKspGenerator(
             .build()
         )
       }
+      addScopeRequiredOverloads(
+        fileSpec,
+        daoType,
+        entityType,
+        searchContentType,
+        generateRemove,
+        scopeClassName,
+        scopeFields,
+      )
     } else {
       fileSpec.addFunction(
         FunSpec.builder("search")
@@ -569,6 +679,100 @@ class ZygardeJpaDaoKspGenerator(
     return builder.build()
   }
 
+  private fun addScopeRequiredOverloads(
+    fileSpec: FileSpec.Builder,
+    daoType: ClassName,
+    entityType: TypeName,
+    searchContentType: LambdaTypeName,
+    generateRemove: Boolean,
+    scopeClassName: ClassName,
+    scopeFields: List<ScopeFieldInfo>,
+  ) {
+    val scopeExample = buildScopeExample(scopeClassName, scopeFields)
+    val message = "此實體已啟用 ScopedQueries：請以第一參數傳入 ${scopeClassName.simpleName}" +
+      "（全放行請顯式傳 $scopeExample）"
+    val deprecated = AnnotationSpec.builder(Deprecated::class)
+      .addMember("%S", message)
+      .addMember("level = %T.ERROR", DeprecationLevel::class)
+      .build()
+    val defaultSearchContent = ParameterSpec.builder("searchContent", searchContentType)
+      .defaultValue("{}")
+      .build()
+
+    fun placeholder(name: String, returnType: TypeName, vararg parameters: ParameterSpec): FunSpec {
+      return FunSpec.builder(name)
+        .receiver(daoType)
+        .addAnnotation(deprecated)
+        .addParameters(parameters.toList())
+        .returns(returnType)
+        .addStatement("error(%S)", message)
+        .build()
+    }
+
+    fileSpec.addFunction(
+      placeholder(
+        "search",
+        List::class.asClassName().parameterizedBy(entityType),
+        defaultSearchContent,
+      )
+    )
+    fileSpec.addFunction(
+      placeholder(
+        "search",
+        List::class.asClassName().parameterizedBy(entityType),
+        ParameterSpec.builder(
+          "sorts",
+          List::class.asClassName().parameterizedBy(SortField::class.asClassName()).copy(nullable = true),
+        ).build(),
+        ParameterSpec.builder("searchContent", searchContentType).build(),
+      )
+    )
+    fileSpec.addFunction(
+      placeholder(
+        "search",
+        List::class.asClassName().parameterizedBy(entityType),
+        ParameterSpec.builder("searchContent", searchContentType).build(),
+        ParameterSpec.builder("limit", Int::class).build(),
+      )
+    )
+    fileSpec.addFunction(placeholder("searchCount", Long::class.asTypeName(), defaultSearchContent))
+    fileSpec.addFunction(placeholder("searchOne", entityType.copy(nullable = true), defaultSearchContent))
+    fileSpec.addFunction(
+      placeholder(
+        "searchOneOrThrow",
+        entityType,
+        ParameterSpec.builder("errorCode", ErrorCode::class).build(),
+        defaultSearchContent,
+      )
+    )
+    fileSpec.addFunction(
+      placeholder(
+        "searchPage",
+        Page::class.asClassName().parameterizedBy(entityType),
+        ParameterSpec.builder("req", PagingAndSortingRequest::class).build(),
+        defaultSearchContent,
+      )
+    )
+    if (generateRemove) {
+      fileSpec.addFunction(placeholder("remove", Long::class.asTypeName(), defaultSearchContent))
+    }
+  }
+
+  private fun buildScopeExample(scopeClassName: ClassName, scopeFields: List<ScopeFieldInfo>): String {
+    val requiredArgs = scopeFields.filterNot { it.nullable }.map { field ->
+      when (field.operator) {
+        ScopeOperator.IN, ScopeOperator.NOT_IN -> "${field.name} = ScopeFilter.All"
+        ScopeOperator.IS_NULL, ScopeOperator.IS_NOT_NULL -> "${field.name} = false"
+      }
+    }
+    val args = requiredArgs.ifEmpty {
+      scopeFields.firstOrNull { it.operator == ScopeOperator.IN || it.operator == ScopeOperator.NOT_IN }
+        ?.let { listOf("${it.name} = ScopeFilter.All") }
+        .orEmpty()
+    }
+    return "${scopeClassName.simpleName}(${args.joinToString()})"
+  }
+
   private fun buildScopedSearchBody(
     entityType: TypeName,
     scopeFields: List<ScopeFieldInfo>,
@@ -583,42 +787,71 @@ class ZygardeJpaDaoKspGenerator(
       UNIT,
     )
 
-    scopeFields.forEach { field ->
-      if (field.nullEquivalent != null) {
-        if (field.nullable) {
-          builder.beginControlFlow("scope.${field.name}?.let·{ scopeValues ->")
-          builder.beginControlFlow("if (scopeValues.any { it.toString() == %S })", field.nullEquivalent)
-          builder.beginControlFlow("or")
-          builder.addStatement("field<%T>(%S) inList scopeValues", field.typeName, field.name)
-          builder.addStatement("field<%T>(%S).isNull()", field.typeName, field.name)
-          builder.endControlFlow()
-          builder.nextControlFlow("else")
-          builder.addStatement("field<%T>(%S) inList scopeValues", field.typeName, field.name)
-          builder.endControlFlow()
-          builder.endControlFlow()
-        } else {
-          builder.beginControlFlow("scope.${field.name}.let·{ scopeValues ->")
-          builder.beginControlFlow("if (scopeValues.any { it.toString() == %S })", field.nullEquivalent)
-          builder.beginControlFlow("or")
-          builder.addStatement("field<%T>(%S) inList scopeValues", field.typeName, field.name)
-          builder.addStatement("field<%T>(%S).isNull()", field.typeName, field.name)
-          builder.endControlFlow()
-          builder.nextControlFlow("else")
-          builder.addStatement("field<%T>(%S) inList scopeValues", field.typeName, field.name)
-          builder.endControlFlow()
-          builder.endControlFlow()
-        }
-      } else if (field.nullable) {
-        builder.addStatement("scope.${field.name}?.let·{ field<%T>(%S) inList it }", field.typeName, field.name)
-      } else {
-        builder.addStatement("field<%T>(%S) inList scope.${field.name}", field.typeName, field.name)
-      }
-    }
+    scopeFields.forEach { field -> builder.addScopePredicate(field) }
 
     builder.addStatement("originalSearchContent()")
     builder.endControlFlow()
     builder.addStatement("return $returnStatement", *returnArgs)
     return builder.build()
+  }
+
+  private fun CodeBlock.Builder.addScopePredicate(field: ScopeFieldInfo) {
+    if (field.operator == ScopeOperator.IS_NULL || field.operator == ScopeOperator.IS_NOT_NULL) {
+      beginControlFlow("if (scope.${field.name} == true)")
+      addStatement(
+        "field<%T>(%S).${if (field.operator == ScopeOperator.IS_NULL) "isNull" else "isNotNull"}()",
+        field.typeName,
+        field.name,
+      )
+      endControlFlow()
+      return
+    }
+
+    beginControlFlow("scope.${field.name}.let·{ scopeFilter ->")
+    beginControlFlow("when (scopeFilter)")
+    addStatement("%T.All -> Unit", ScopeFilter::class)
+    beginControlFlow("is %T.Of ->", ScopeFilter::class)
+    addStatement("val scopeValues = scopeFilter.values")
+    beginControlFlow("if (scopeValues.isEmpty())")
+    beginControlFlow("and")
+    addStatement("field<%T>(%S).isNull()", field.typeName, field.name)
+    addStatement("field<%T>(%S).isNotNull()", field.typeName, field.name)
+    endControlFlow()
+    nextControlFlow("else")
+    addMembershipPredicate(field)
+    endControlFlow()
+    endControlFlow()
+    endControlFlow()
+    endControlFlow()
+  }
+
+  private fun CodeBlock.Builder.addMembershipPredicate(field: ScopeFieldInfo) {
+    if (field.nullEquivalent == null) {
+      val operation = if (field.operator == ScopeOperator.IN) "inList" else "notInList"
+      addStatement("field<%T>(%S) $operation scopeValues", field.typeName, field.name)
+      return
+    }
+
+    beginControlFlow("if (scopeValues.any { it.toString() == %S })", field.nullEquivalent)
+    beginControlFlow(if (field.operator == ScopeOperator.IN) "or" else "and")
+    val operation = if (field.operator == ScopeOperator.IN) "inList" else "notInList"
+    addStatement("field<%T>(%S) $operation scopeValues", field.typeName, field.name)
+    addStatement(
+      "field<%T>(%S).${if (field.operator == ScopeOperator.IN) "isNull" else "isNotNull"}()",
+      field.typeName,
+      field.name,
+    )
+    endControlFlow()
+    nextControlFlow("else")
+    if (field.operator == ScopeOperator.IN) {
+      addStatement("field<%T>(%S) inList scopeValues", field.typeName, field.name)
+    } else {
+      beginControlFlow("or")
+      addStatement("field<%T>(%S) notInList scopeValues", field.typeName, field.name)
+      addStatement("field<%T>(%S).isNull()", field.typeName, field.name)
+      endControlFlow()
+    }
+    endControlFlow()
   }
 
   private fun searchContentLambdaType(entityType: TypeName): LambdaTypeName {

--- a/modules-jpa/zygarde-jpa-codegen-ksp/src/test/kotlin/zygarde/codegen/ksp/ZygardeJpaKspProcessorTest.kt
+++ b/modules-jpa/zygarde-jpa-codegen-ksp/src/test/kotlin/zygarde/codegen/ksp/ZygardeJpaKspProcessorTest.kt
@@ -56,6 +56,7 @@ class ZygardeJpaKspProcessorTest {
     simpleBookDaoExtensions shouldNotContain "JsonNode"
     simpleBookDaoExtensions shouldNotContain "objectMapper"
     simpleBookDaoExtensions shouldNotContain "patch.has("
+    simpleBookDaoExtensions shouldNotContain "ScopeFilter"
   }
 
   @Test
@@ -131,6 +132,8 @@ class ZygardeJpaKspProcessorTest {
     extContent shouldContain "fun ScopedOrderDao.searchCount("
     extContent shouldContain "fun <PATCH> ScopedOrderDao.patchOne("
     extContent shouldContain "searchOneOrThrow(scope, errorCode, searchContent)"
+    extContent shouldContain "level = DeprecationLevel.ERROR"
+    extContent shouldContain "請以第一參數傳入 ScopedOrderScope"
   }
 
   @Test
@@ -232,6 +235,34 @@ class ZygardeJpaKspProcessorTest {
   }
 
   @Test
+  fun `ScopeOp should generate selected predicates and Boolean null checks`() {
+    val compilation = KotlinCompilation().apply {
+      sources = listOf(
+        ClassPathResource("codegen/jpa/TestGenerateScopedQuery.kt").file
+      ).map { SourceFile.fromPath(it) }
+      symbolProcessorProviders = listOf(ZygardeJpaKspProcessorProvider())
+      inheritClassPath = true
+      messageOutputStream = System.out
+    }
+    val result = compilation.compile()
+    result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+    val scopeContent = compilation.kspSourcesDir.walkTopDown()
+      .first { it.name == "AdvancedScopedOrderScope.kt" }.readText()
+    scopeContent shouldContain "val status: ScopeFilter<String> = ScopeFilter.All"
+    scopeContent shouldContain "status: Collection<String>?,"
+    scopeContent shouldContain "deletedAt: Boolean? = null"
+    scopeContent shouldContain "linkedId: Boolean? = null"
+
+    val extContent = compilation.kspSourcesDir.walkTopDown()
+      .first { it.name == "AdvancedScopedOrderDaoExtensions.kt" }.readText()
+    extContent shouldContain "field<String>(\"status\") notInList scopeValues"
+    extContent shouldContain "scopeValues.any { it.toString() == \"ARCHIVED\" }"
+    extContent shouldContain "field<String>(\"deletedAt\").isNull()"
+    extContent shouldContain "field<Long>(\"linkedId\").isNotNull()"
+  }
+
+  @Test
   fun `boolean scope property should be included in scope data class`() {
     val compilation = KotlinCompilation().apply {
       sources = listOf(
@@ -263,7 +294,7 @@ class ZygardeJpaKspProcessorTest {
   }
 
   @Test
-  fun `scope data class should wrap field type with Collection and provide convenience constructor`() {
+  fun `scope data class should use ScopeFilter and preserve collection and single-value constructors`() {
     val compilation = KotlinCompilation().apply {
       sources = listOf(
         ClassPathResource("codegen/jpa/TestGenerateScopedQuery.kt").file
@@ -283,15 +314,90 @@ class ZygardeJpaKspProcessorTest {
 
     val scopeContent = generatedFiles.first { it.name == "RegionalProductScope.kt" }.readText()
     scopeContent shouldContain "data class RegionalProductScope"
-    // Primary constructor should use Collection<Long>
+    // Primary constructor distinguishes All from Of(values).
+    scopeContent shouldContain "val regionId: ScopeFilter<Long>"
+    // Compatibility constructor should continue accepting Collection<Long>.
     scopeContent shouldContain "Collection<Long>"
     // Convenience constructor should accept single Long value
-    scopeContent shouldContain "listOf(regionId)"
+    scopeContent shouldContain "ScopeFilter.Of(listOf(regionId))"
 
     // Extension functions should use scope
     val extContent = generatedFiles.first { it.name == "RegionalProductDaoExtensions.kt" }.readText()
     extContent shouldContain "scope: RegionalProductScope"
-    extContent shouldContain "field<Long>(\"regionId\") inList scope.regionId"
+    extContent shouldContain "ScopeFilter.All -> Unit"
+    extContent shouldContain "val scopeValues = scopeFilter.values"
+    extContent shouldContain "field<Long>(\"regionId\") inList scopeValues"
+  }
+
+  @Test
+  fun `nullable scope constructors should resolve null without ambiguity`() {
+    val fixture = ClassPathResource("codegen/jpa/TestGenerateScopedQuery.kt").file
+    val compilation = KotlinCompilation().apply {
+      sources = listOf(SourceFile.fromPath(fixture))
+      symbolProcessorProviders = listOf(ZygardeJpaKspProcessorProvider())
+      inheritClassPath = true
+    }
+    val generated = compilation.compile()
+    generated.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+    val result = KotlinCompilation().apply {
+      sources = listOf(SourceFile.fromPath(fixture)) +
+        compilation.kspSourcesDir.walkTopDown()
+          .filter { it.name == "ScopedOrderScope.kt" || it.name == "AdvancedScopedOrderScope.kt" }
+          .map(SourceFile::fromPath)
+          .toList() +
+        SourceFile.kotlin(
+          "ScopeConstructorUsage.kt",
+          """
+          package codegen.jpa
+
+          import zygarde.data.jpa.search.ScopeFilter
+          import zygarde.generated.data.dao.AdvancedScopedOrderScope
+          import zygarde.generated.data.dao.ScopedOrderScope
+
+          fun scopeConstructors() {
+            ScopedOrderScope()
+            ScopedOrderScope(platformSource = null)
+            ScopedOrderScope(null)
+            ScopedOrderScope(platformSource = ScopeFilter.All)
+            ScopedOrderScope(platformSource = emptyList())
+            ScopedOrderScope(platformSource = "HOTCAKE")
+            AdvancedScopedOrderScope()
+            AdvancedScopedOrderScope(status = null)
+            AdvancedScopedOrderScope(deletedAt = true)
+          }
+          """.trimIndent(),
+        )
+      inheritClassPath = true
+    }.compile()
+
+    result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+    result.messages shouldNotContain "Overload resolution ambiguity"
+  }
+
+  @Test
+  fun `scope data class should avoid constructors with the same erased JVM signature`() {
+    val compilation = KotlinCompilation().apply {
+      sources = listOf(
+        ClassPathResource("codegen/jpa/TestGenerateScopedQuery.kt").file
+      ).map { SourceFile.fromPath(it) }
+      symbolProcessorProviders = listOf(ZygardeJpaKspProcessorProvider())
+      inheritClassPath = true
+      messageOutputStream = System.out
+    }
+    val result = compilation.compile()
+    result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+    val scopeContent = compilation.kspSourcesDir.walkTopDown()
+      .first { it.name == "FilterValueEntityScope.kt" }.readText()
+    scopeContent shouldContain "val filter: ScopeFilter<ScopeFilter<String>>"
+    scopeContent shouldContain "filter: Collection<ScopeFilter<String>>"
+    scopeContent shouldNotContain "constructor(filter: ScopeFilter<String>)"
+
+    val collectionScopeContent = compilation.kspSourcesDir.walkTopDown()
+      .first { it.name == "CollectionValueEntityScope.kt" }.readText()
+    collectionScopeContent shouldNotContain "constructor(values: Collection<String>)"
+    collectionScopeContent shouldNotContain "constructor(values: java.util.Collection<String>)"
   }
 
   @Test
@@ -346,7 +452,7 @@ class ZygardeJpaKspProcessorTest {
 
     val extContent = generatedFiles.first { it.name == "OwnedDocumentDaoExtensions.kt" }.readText()
     extContent shouldContain "scope: OwnedDocumentScope"
-    extContent shouldContain "field<Long>(\"ownerId\") inList scope.ownerId"
+    extContent shouldContain "field<Long>(\"ownerId\") inList scopeValues"
   }
 
   @Test
@@ -393,6 +499,11 @@ class ZygardeJpaKspProcessorTest {
 
     extContent shouldContain "fun ScopedOrderDao.remove("
     extContent shouldContain "scope: ScopedOrderScope"
+    val removeFunctions = extContent.split("fun ScopedOrderDao.remove(").drop(1)
+    removeFunctions.size shouldBe 2
+    removeFunctions.forEach { removeFunction ->
+      removeFunction shouldContain "): Long"
+    }
     // remove signature takes scope first
     val removeHead = extContent
       .substringAfter("fun ScopedOrderDao.remove(")
@@ -402,6 +513,71 @@ class ZygardeJpaKspProcessorTest {
     val removeBody = extContent.substringAfter("fun ScopedOrderDao.remove(")
     removeBody shouldContain "originalSearchContent"
     removeBody shouldContain "delete(SearchSpecBuilder.buildSpec(searchContent))"
+  }
+
+  @Test
+  fun `missing scope should report an actionable compiler error`() {
+    val fixture = ClassPathResource("codegen/jpa/TestGenerateScopedQuery.kt").file
+    val compilation = KotlinCompilation().apply {
+      sources = listOf(SourceFile.fromPath(fixture))
+      symbolProcessorProviders = listOf(ZygardeJpaKspProcessorProvider())
+      inheritClassPath = true
+      kspArgs[ZygardeJpaKspOptions.DAO_INHERIT] = "zygarde.data.jpa.dao.ZygardeEnhancedDao"
+      kspArgs[ZygardeJpaKspOptions.DAO_COMBINE] = "false"
+    }
+    val generated = compilation.compile()
+    generated.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+    val requiredGeneratedFiles = setOf(
+      "ScopedOrderDao.kt",
+      "ScopedOrderScope.kt",
+      "ScopedOrderDaoExtensions.kt",
+      "AdvancedScopedOrderScope.kt",
+    )
+    val result = KotlinCompilation().apply {
+      sources = listOf(SourceFile.fromPath(fixture)) +
+        compilation.kspSourcesDir.walkTopDown()
+          .filter { it.name in requiredGeneratedFiles }
+          .map(SourceFile::fromPath)
+          .toList() +
+        SourceFile.kotlin(
+          "MissingScopeUsage.kt",
+          """
+          package codegen.jpa
+
+          import zygarde.generated.data.dao.ScopedOrderDao
+          import zygarde.generated.data.dao.AdvancedScopedOrderScope
+          import zygarde.core.exception.CommonErrorCode
+          import zygarde.data.api.PagingAndSortingRequest
+          import zygarde.generated.data.dao.remove
+          import zygarde.generated.data.dao.search
+          import zygarde.generated.data.dao.searchCount
+          import zygarde.generated.data.dao.searchOne
+          import zygarde.generated.data.dao.searchOneOrThrow
+          import zygarde.generated.data.dao.searchPage
+
+          fun missingScope(dao: ScopedOrderDao) {
+            AdvancedScopedOrderScope()
+            AdvancedScopedOrderScope(deletedAt = true)
+            dao.search { field<String>("platformSource") eq "HOTCAKE" }
+            dao.search(sorts = null) { field<String>("platformSource") eq "HOTCAKE" }
+            dao.search(searchContent = { field<String>("platformSource") eq "HOTCAKE" }, limit = 1)
+            dao.searchCount { field<String>("platformSource") eq "HOTCAKE" }
+            dao.searchOne { field<String>("platformSource") eq "HOTCAKE" }
+            dao.searchOneOrThrow(CommonErrorCode.ERROR) { field<String>("platformSource") eq "HOTCAKE" }
+            dao.searchPage(PagingAndSortingRequest()) { field<String>("platformSource") eq "HOTCAKE" }
+            dao.remove { field<String>("platformSource") eq "HOTCAKE" }
+          }
+          """.trimIndent(),
+        )
+      inheritClassPath = true
+    }.compile()
+
+    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+    result.messages shouldContain "請以第一參數傳入 ScopedOrderScope"
+    result.messages shouldContain "ScopedOrderScope(platformSource = ScopeFilter.All)"
+    result.messages shouldNotContain "Overload resolution ambiguity"
+    result.messages shouldNotContain "Unresolved reference: field"
   }
 
   @Test

--- a/modules-jpa/zygarde-jpa-codegen-ksp/src/test/resources/codegen/jpa/TestGenerateScopedQuery.kt
+++ b/modules-jpa/zygarde-jpa-codegen-ksp/src/test/resources/codegen/jpa/TestGenerateScopedQuery.kt
@@ -2,7 +2,10 @@ package codegen.jpa
 
 import zygarde.codegen.NullEquivalent
 import zygarde.codegen.ScopeMarker
+import zygarde.codegen.ScopeOp
+import zygarde.codegen.ScopeOperator
 import zygarde.codegen.ZyModel
+import zygarde.data.jpa.search.ScopeFilter
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 
@@ -22,6 +25,29 @@ interface FeatureToggleScoped {
   val enabled: Boolean
 }
 
+@ScopeMarker
+interface AdvancedScopedEntity {
+  @get:NullEquivalent("ARCHIVED")
+  @get:ScopeOp(ScopeOperator.NOT_IN)
+  val status: String?
+
+  @get:ScopeOp(ScopeOperator.IS_NULL)
+  val deletedAt: String?
+
+  @get:ScopeOp(ScopeOperator.IS_NOT_NULL)
+  val linkedId: Long?
+}
+
+@ScopeMarker
+interface FilterValueScoped {
+  val filter: ScopeFilter<String>
+}
+
+@ScopeMarker
+interface CollectionValueScoped {
+  val values: Collection<String>
+}
+
 @ZyModel
 @Entity
 class ScopedOrder(
@@ -38,6 +64,32 @@ class MultiScopedOrder(
   override val platformSource: String? = null,
   override val tenantId: String = "",
 ) : PlatformScopedEntity, TenantScopedEntity
+
+@ZyModel
+@Entity
+class AdvancedScopedOrder(
+  @Id
+  var id: Long,
+  override val status: String? = null,
+  override val deletedAt: String? = null,
+  override val linkedId: Long? = null,
+) : AdvancedScopedEntity
+
+@ZyModel
+@Entity
+class FilterValueEntity(
+  @Id
+  var id: Long,
+  override val filter: ScopeFilter<String> = ScopeFilter.All,
+) : FilterValueScoped
+
+@ZyModel
+@Entity
+class CollectionValueEntity(
+  @Id
+  var id: Long,
+  override val values: Collection<String> = emptyList(),
+) : CollectionValueScoped
 
 @ScopeMarker
 interface RegionScoped {

--- a/modules-jpa/zygarde-jpa-codegen/src/main/kotlin/zygarde/codegen/generator/impl/ZygardeJpaDaoGenerator.kt
+++ b/modules-jpa/zygarde-jpa-codegen/src/main/kotlin/zygarde/codegen/generator/impl/ZygardeJpaDaoGenerator.kt
@@ -1,5 +1,6 @@
 package zygarde.codegen.generator.impl
 
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
@@ -7,6 +8,7 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
@@ -23,6 +25,8 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.stereotype.Component
 import zygarde.codegen.NullEquivalent
 import zygarde.codegen.ScopeMarker
+import zygarde.codegen.ScopeOp
+import zygarde.codegen.ScopeOperator
 import zygarde.codegen.ZygardeJpaCodegenKaptOptions.DAO_COMBINE
 import zygarde.codegen.ZygardeJpaCodegenKaptOptions.DAO_INHERIT
 import zygarde.codegen.ZygardeJpaCodegenKaptOptions.DAO_PACKAGE
@@ -45,6 +49,7 @@ import zygarde.data.api.PagingAndSortingRequest
 import zygarde.data.api.SortField
 import zygarde.data.jpa.search.EnhancedSearch
 import zygarde.data.jpa.search.SearchSpecBuilder
+import zygarde.data.jpa.search.ScopeFilter
 import java.io.File
 import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.element.Element
@@ -160,6 +165,7 @@ class ZygardeJpaDaoGenerator(
     val typeName: TypeName,
     val nullable: Boolean,
     val nullEquivalent: String?,
+    val operator: ScopeOperator,
   )
 
   private fun collectScopeFields(element: Element): List<ScopeFieldInfo> {
@@ -189,14 +195,23 @@ class ZygardeJpaDaoGenerator(
               }?.elementValues?.entries?.find {
                 it.key.simpleName.toString() == "value"
               }?.value?.value as? String
+            val operator = method.getAnnotation(ScopeOp::class.java)?.value
+              ?: method.annotationMirrors.find {
+                it.annotationType.asElement().simpleName.toString() == "ScopeOp"
+              }?.elementValues?.entries?.find {
+                it.key.simpleName.toString() == "value"
+              }?.value?.value?.toString()?.let(ScopeOperator::valueOf)
+              ?: ScopeOperator.IN
+            val isMembership = operator == ScopeOperator.IN || operator == ScopeOperator.NOT_IN
             val fieldTypeName = returnTypeMirror.kotlinTypeName(false)
             fields.putIfAbsent(
               propName,
               ScopeFieldInfo(
                 name = propName,
                 typeName = fieldTypeName,
-                nullable = isNullable || nullEquivalent != null,
-                nullEquivalent = nullEquivalent,
+                nullable = isNullable || (isMembership && nullEquivalent != null),
+                nullEquivalent = nullEquivalent.takeIf { isMembership },
+                operator = operator,
               )
             )
           }
@@ -213,17 +228,33 @@ class ZygardeJpaDaoGenerator(
   ) {
     val scopeClassName = "${entityName}Scope"
     val collectionType = Collection::class.asClassName()
+    val javaCollectionType = ClassName("java.util", "Collection")
+    val scopeFilterType = ScopeFilter::class.asClassName()
 
-    // Primary constructor: all fields as Collection<T> (nullable if field is nullable on interface)
+    // Primary constructor: membership fields use ScopeFilter<T>; null-check operators use Boolean.
     val primaryConstructor = FunSpec.constructorBuilder()
     val properties = mutableListOf<PropertySpec>()
 
     fields.forEach { field ->
-      val collectionOfField = collectionType.parameterizedBy(field.typeName)
-      val paramType = if (field.nullable) collectionOfField.copy(nullable = true) else collectionOfField
+      val fieldScopeType = when (field.operator) {
+        ScopeOperator.IN, ScopeOperator.NOT_IN -> scopeFilterType.parameterizedBy(field.typeName)
+        ScopeOperator.IS_NULL, ScopeOperator.IS_NOT_NULL -> Boolean::class.asTypeName()
+      }
+      val paramType = when (field.operator) {
+        ScopeOperator.IN, ScopeOperator.NOT_IN -> fieldScopeType
+        ScopeOperator.IS_NULL, ScopeOperator.IS_NOT_NULL -> if (field.nullable) fieldScopeType.copy(nullable = true) else fieldScopeType
+      }
       primaryConstructor.addParameter(
         ParameterSpec.builder(field.name, paramType)
-          .also { if (field.nullable) it.defaultValue("null") }
+          .also {
+            if (field.nullable) {
+              if (field.operator == ScopeOperator.IN || field.operator == ScopeOperator.NOT_IN) {
+                it.defaultValue("%T.All", ScopeFilter::class)
+              } else {
+                it.defaultValue("null")
+              }
+            }
+          }
           .build()
       )
       properties.add(
@@ -233,29 +264,102 @@ class ZygardeJpaDaoGenerator(
       )
     }
 
+    // Compatibility constructor: collections used by the original generated API.
+    val collectionConstructor = FunSpec.constructorBuilder()
+    val collectionThisArgs = mutableListOf<CodeBlock>()
+    val requiredCompatibilityField = fields
+      .filter { it.operator == ScopeOperator.IN || it.operator == ScopeOperator.NOT_IN }
+      .takeIf { membershipFields -> membershipFields.all { it.nullable } }
+      ?.firstOrNull()
+    fields.forEach { field ->
+      val baseType = when (field.operator) {
+        ScopeOperator.IN, ScopeOperator.NOT_IN -> collectionType.parameterizedBy(field.typeName)
+        ScopeOperator.IS_NULL, ScopeOperator.IS_NOT_NULL -> Boolean::class.asTypeName()
+      }
+      val paramType = if (field.nullable) baseType.copy(nullable = true) else baseType
+      collectionConstructor.addParameter(
+        ParameterSpec.builder(field.name, paramType)
+          .also { if (field.nullable && field != requiredCompatibilityField) it.defaultValue("null") }
+          .build()
+      )
+      when (field.operator) {
+        ScopeOperator.IN, ScopeOperator.NOT_IN -> if (field.nullable) {
+          collectionThisArgs.add(
+            CodeBlock.of("${field.name} = ${field.name}?.let·{ %T.Of(it) } ?: %T.All", ScopeFilter::class, ScopeFilter::class)
+          )
+        } else {
+          collectionThisArgs.add(CodeBlock.of("${field.name} = %T.Of(${field.name})", ScopeFilter::class))
+        }
+        ScopeOperator.IS_NULL, ScopeOperator.IS_NOT_NULL -> {
+          collectionThisArgs.add(CodeBlock.of("${field.name} = ${field.name}"))
+        }
+      }
+    }
+    collectionConstructor.callThisConstructor(collectionThisArgs)
+
     // Convenience constructor: single values
     val convenienceConstructor = FunSpec.constructorBuilder()
     val convenienceThisArgs = mutableListOf<CodeBlock>()
     fields.forEach { field ->
-      val singleType = if (field.nullable) field.typeName.copy(nullable = true) else field.typeName
+      val baseType = when (field.operator) {
+        ScopeOperator.IN, ScopeOperator.NOT_IN -> field.typeName
+        ScopeOperator.IS_NULL, ScopeOperator.IS_NOT_NULL -> Boolean::class.asTypeName()
+      }
+      val singleType = if (field.nullable && field != requiredCompatibilityField) baseType.copy(nullable = true) else baseType
       convenienceConstructor.addParameter(
         ParameterSpec.builder(field.name, singleType)
-          .also { if (field.nullable) it.defaultValue("null") }
+          .also { if (field.nullable && field != requiredCompatibilityField) it.defaultValue("null") }
           .build()
       )
-      if (field.nullable) {
-        convenienceThisArgs.add(CodeBlock.of("${field.name} = ${field.name}?.let·{ listOf(it) }"))
-      } else {
-        convenienceThisArgs.add(CodeBlock.of("${field.name} = listOf(${field.name})"))
+      when (field.operator) {
+        ScopeOperator.IN, ScopeOperator.NOT_IN -> if (field.nullable && field != requiredCompatibilityField) {
+          convenienceThisArgs.add(
+            CodeBlock.of("${field.name} = ${field.name}?.let·{ %T.Of(listOf(it)) } ?: %T.All", ScopeFilter::class, ScopeFilter::class)
+          )
+        } else {
+          convenienceThisArgs.add(CodeBlock.of("${field.name} = %T.Of(listOf(${field.name}))", ScopeFilter::class))
+        }
+        ScopeOperator.IS_NULL, ScopeOperator.IS_NOT_NULL -> {
+          convenienceThisArgs.add(CodeBlock.of("${field.name} = ${field.name}"))
+        }
       }
     }
     convenienceConstructor.callThisConstructor(convenienceThisArgs)
 
+    val hasMembershipField = fields.any { it.operator == ScopeOperator.IN || it.operator == ScopeOperator.NOT_IN }
+    val convenienceErasedTypes = fields.map { field ->
+      when (field.operator) {
+        ScopeOperator.IN, ScopeOperator.NOT_IN -> when (val type = field.typeName) {
+          is ClassName -> type
+          is ParameterizedTypeName -> type.rawType
+          else -> null
+        }
+        ScopeOperator.IS_NULL, ScopeOperator.IS_NOT_NULL -> Boolean::class.asClassName()
+      }
+    }
+    val convenienceCollidesWithPrimary = fields.zip(convenienceErasedTypes).all { (field, erasedType) ->
+      field.operator == ScopeOperator.IS_NULL ||
+        field.operator == ScopeOperator.IS_NOT_NULL ||
+        erasedType == scopeFilterType
+    }
+    val convenienceCollidesWithCollection = fields.zip(convenienceErasedTypes).all { (field, erasedType) ->
+      field.operator == ScopeOperator.IS_NULL ||
+        field.operator == ScopeOperator.IS_NOT_NULL ||
+        erasedType == collectionType ||
+        erasedType == javaCollectionType
+    }
     val typeSpec = TypeSpec.classBuilder(scopeClassName)
       .addModifiers(com.squareup.kotlinpoet.KModifier.DATA)
       .primaryConstructor(primaryConstructor.build())
       .addProperties(properties)
-      .addFunction(convenienceConstructor.build())
+      .also {
+        if (hasMembershipField) {
+          it.addFunction(collectionConstructor.build())
+          if (!convenienceCollidesWithPrimary && !convenienceCollidesWithCollection) {
+            it.addFunction(convenienceConstructor.build())
+          }
+        }
+      }
       .build()
 
     FileSpec.builder(daoPackage, scopeClassName)
@@ -417,6 +521,15 @@ class ZygardeJpaDaoGenerator(
             .build()
         )
       }
+      addScopeRequiredOverloads(
+        fileSpec,
+        daoType,
+        entityType,
+        searchContentType,
+        generateRemove,
+        scopeClassName,
+        scopeFields,
+      )
     } else {
       // Non-scoped entity — generate extension functions without scope parameter (unchanged)
       fileSpec.addFunction(
@@ -569,6 +682,100 @@ class ZygardeJpaDaoGenerator(
     return builder.build()
   }
 
+  private fun addScopeRequiredOverloads(
+    fileSpec: FileSpec.Builder,
+    daoType: ClassName,
+    entityType: TypeName,
+    searchContentType: LambdaTypeName,
+    generateRemove: Boolean,
+    scopeClassName: ClassName,
+    scopeFields: List<ScopeFieldInfo>,
+  ) {
+    val scopeExample = buildScopeExample(scopeClassName, scopeFields)
+    val message = "此實體已啟用 ScopedQueries：請以第一參數傳入 ${scopeClassName.simpleName}" +
+      "（全放行請顯式傳 $scopeExample）"
+    val deprecated = AnnotationSpec.builder(Deprecated::class)
+      .addMember("%S", message)
+      .addMember("level = %T.ERROR", DeprecationLevel::class)
+      .build()
+    val defaultSearchContent = ParameterSpec.builder("searchContent", searchContentType)
+      .defaultValue("{}")
+      .build()
+
+    fun placeholder(name: String, returnType: TypeName, vararg parameters: ParameterSpec): FunSpec {
+      return FunSpec.builder(name)
+        .receiver(daoType)
+        .addAnnotation(deprecated)
+        .addParameters(parameters.toList())
+        .returns(returnType)
+        .addStatement("error(%S)", message)
+        .build()
+    }
+
+    fileSpec.addFunction(
+      placeholder(
+        "search",
+        List::class.asClassName().parameterizedBy(entityType),
+        defaultSearchContent,
+      )
+    )
+    fileSpec.addFunction(
+      placeholder(
+        "search",
+        List::class.asClassName().parameterizedBy(entityType),
+        ParameterSpec.builder(
+          "sorts",
+          List::class.asClassName().parameterizedBy(SortField::class.asClassName()).copy(nullable = true),
+        ).build(),
+        ParameterSpec.builder("searchContent", searchContentType).build(),
+      )
+    )
+    fileSpec.addFunction(
+      placeholder(
+        "search",
+        List::class.asClassName().parameterizedBy(entityType),
+        ParameterSpec.builder("searchContent", searchContentType).build(),
+        ParameterSpec.builder("limit", Int::class).build(),
+      )
+    )
+    fileSpec.addFunction(placeholder("searchCount", Long::class.asTypeName(), defaultSearchContent))
+    fileSpec.addFunction(placeholder("searchOne", entityType.copy(nullable = true), defaultSearchContent))
+    fileSpec.addFunction(
+      placeholder(
+        "searchOneOrThrow",
+        entityType,
+        ParameterSpec.builder("errorCode", ErrorCode::class).build(),
+        defaultSearchContent,
+      )
+    )
+    fileSpec.addFunction(
+      placeholder(
+        "searchPage",
+        Page::class.asClassName().parameterizedBy(entityType),
+        ParameterSpec.builder("req", PagingAndSortingRequest::class).build(),
+        defaultSearchContent,
+      )
+    )
+    if (generateRemove) {
+      fileSpec.addFunction(placeholder("remove", Long::class.asTypeName(), defaultSearchContent))
+    }
+  }
+
+  private fun buildScopeExample(scopeClassName: ClassName, scopeFields: List<ScopeFieldInfo>): String {
+    val requiredArgs = scopeFields.filterNot { it.nullable }.map { field ->
+      when (field.operator) {
+        ScopeOperator.IN, ScopeOperator.NOT_IN -> "${field.name} = ScopeFilter.All"
+        ScopeOperator.IS_NULL, ScopeOperator.IS_NOT_NULL -> "${field.name} = false"
+      }
+    }
+    val args = requiredArgs.ifEmpty {
+      scopeFields.firstOrNull { it.operator == ScopeOperator.IN || it.operator == ScopeOperator.NOT_IN }
+        ?.let { listOf("${it.name} = ScopeFilter.All") }
+        .orEmpty()
+    }
+    return "${scopeClassName.simpleName}(${args.joinToString()})"
+  }
+
   /**
    * Builds a code block that wraps the original searchContent lambda with scope predicates.
    *
@@ -597,43 +804,71 @@ class ZygardeJpaDaoGenerator(
       UNIT,
     )
 
-    scopeFields.forEach { field ->
-      if (field.nullEquivalent != null) {
-        // NullEquivalent field: generate OR IS NULL when null-equivalent value is present
-        if (field.nullable) {
-          builder.beginControlFlow("scope.${field.name}?.let·{ scopeValues ->")
-          builder.beginControlFlow("if (scopeValues.any { it.toString() == %S })", field.nullEquivalent)
-          builder.beginControlFlow("or")
-          builder.addStatement("field<%T>(%S) inList scopeValues", field.typeName, field.name)
-          builder.addStatement("field<%T>(%S).isNull()", field.typeName, field.name)
-          builder.endControlFlow()
-          builder.nextControlFlow("else")
-          builder.addStatement("field<%T>(%S) inList scopeValues", field.typeName, field.name)
-          builder.endControlFlow()
-          builder.endControlFlow()
-        } else {
-          builder.beginControlFlow("scope.${field.name}.let·{ scopeValues ->")
-          builder.beginControlFlow("if (scopeValues.any { it.toString() == %S })", field.nullEquivalent)
-          builder.beginControlFlow("or")
-          builder.addStatement("field<%T>(%S) inList scopeValues", field.typeName, field.name)
-          builder.addStatement("field<%T>(%S).isNull()", field.typeName, field.name)
-          builder.endControlFlow()
-          builder.nextControlFlow("else")
-          builder.addStatement("field<%T>(%S) inList scopeValues", field.typeName, field.name)
-          builder.endControlFlow()
-          builder.endControlFlow()
-        }
-      } else if (field.nullable) {
-        builder.addStatement("scope.${field.name}?.let·{ field<%T>(%S) inList it }", field.typeName, field.name)
-      } else {
-        builder.addStatement("field<%T>(%S) inList scope.${field.name}", field.typeName, field.name)
-      }
-    }
+    scopeFields.forEach { field -> builder.addScopePredicate(field) }
 
     builder.addStatement("originalSearchContent()")
     builder.endControlFlow()
     builder.addStatement("return $returnStatement", *returnArgs)
     return builder.build()
+  }
+
+  private fun CodeBlock.Builder.addScopePredicate(field: ScopeFieldInfo) {
+    if (field.operator == ScopeOperator.IS_NULL || field.operator == ScopeOperator.IS_NOT_NULL) {
+      beginControlFlow("if (scope.${field.name} == true)")
+      addStatement(
+        "field<%T>(%S).${if (field.operator == ScopeOperator.IS_NULL) "isNull" else "isNotNull"}()",
+        field.typeName,
+        field.name,
+      )
+      endControlFlow()
+      return
+    }
+
+    beginControlFlow("scope.${field.name}.let·{ scopeFilter ->")
+    beginControlFlow("when (scopeFilter)")
+    addStatement("%T.All -> Unit", ScopeFilter::class)
+    beginControlFlow("is %T.Of ->", ScopeFilter::class)
+    addStatement("val scopeValues = scopeFilter.values")
+    beginControlFlow("if (scopeValues.isEmpty())")
+    beginControlFlow("and")
+    addStatement("field<%T>(%S).isNull()", field.typeName, field.name)
+    addStatement("field<%T>(%S).isNotNull()", field.typeName, field.name)
+    endControlFlow()
+    nextControlFlow("else")
+    addMembershipPredicate(field)
+    endControlFlow()
+    endControlFlow()
+    endControlFlow()
+    endControlFlow()
+  }
+
+  private fun CodeBlock.Builder.addMembershipPredicate(field: ScopeFieldInfo) {
+    if (field.nullEquivalent == null) {
+      val operation = if (field.operator == ScopeOperator.IN) "inList" else "notInList"
+      addStatement("field<%T>(%S) $operation scopeValues", field.typeName, field.name)
+      return
+    }
+
+    beginControlFlow("if (scopeValues.any { it.toString() == %S })", field.nullEquivalent)
+    beginControlFlow(if (field.operator == ScopeOperator.IN) "or" else "and")
+    val operation = if (field.operator == ScopeOperator.IN) "inList" else "notInList"
+    addStatement("field<%T>(%S) $operation scopeValues", field.typeName, field.name)
+    addStatement(
+      "field<%T>(%S).${if (field.operator == ScopeOperator.IN) "isNull" else "isNotNull"}()",
+      field.typeName,
+      field.name,
+    )
+    endControlFlow()
+    nextControlFlow("else")
+    if (field.operator == ScopeOperator.IN) {
+      addStatement("field<%T>(%S) inList scopeValues", field.typeName, field.name)
+    } else {
+      beginControlFlow("or")
+      addStatement("field<%T>(%S) notInList scopeValues", field.typeName, field.name)
+      addStatement("field<%T>(%S).isNull()", field.typeName, field.name)
+      endControlFlow()
+    }
+    endControlFlow()
   }
 
   private fun searchContentLambdaType(entityType: TypeName): LambdaTypeName {

--- a/modules-jpa/zygarde-jpa-codegen/src/test/kotlin/zygarde/codegen/processor/ZygardeJpaDaoGeneratorTest.kt
+++ b/modules-jpa/zygarde-jpa-codegen/src/test/kotlin/zygarde/codegen/processor/ZygardeJpaDaoGeneratorTest.kt
@@ -53,6 +53,7 @@ class ZygardeJpaDaoGeneratorTest {
     simpleBookDaoExtensions shouldNotContain "JsonNode"
     simpleBookDaoExtensions shouldNotContain "objectMapper"
     simpleBookDaoExtensions shouldNotContain "patch.has("
+    simpleBookDaoExtensions shouldNotContain "ScopeFilter"
   }
 
   @Test
@@ -121,6 +122,8 @@ class ZygardeJpaDaoGeneratorTest {
     extContent shouldContain "fun ScopedOrderDao.searchCount("
     extContent shouldContain "fun <PATCH> ScopedOrderDao.patchOne("
     extContent shouldContain "searchOneOrThrow(scope, errorCode, searchContent)"
+    extContent shouldContain "level = DeprecationLevel.ERROR"
+    extContent shouldContain "請以第一參數傳入 ScopedOrderScope"
   }
 
   @Test
@@ -216,6 +219,32 @@ class ZygardeJpaDaoGeneratorTest {
   }
 
   @Test
+  fun `ScopeOp should generate selected predicates and Boolean null checks`() {
+    val result = KotlinCompilation().apply {
+      sources = listOf(
+        ClassPathResource("codegen/jpa/TestGenerateScopedQuery.kt").file
+      ).map { SourceFile.fromPath(it) }
+      jvmTarget = JvmTarget.JVM_17.description
+      annotationProcessors = listOf(ZygardeJpaProcessor())
+      inheritClassPath = true
+      messageOutputStream = System.out
+    }.compile()
+    result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+    val scopeContent = result.generatedFiles.first { it.name == "AdvancedScopedOrderScope.kt" }.readText()
+    scopeContent shouldContain "val status: ScopeFilter<String> = ScopeFilter.All"
+    scopeContent shouldContain "status: Collection<String>?,"
+    scopeContent shouldContain "deletedAt: Boolean? = null"
+    scopeContent shouldContain "linkedId: Boolean? = null"
+
+    val extContent = result.generatedFiles.first { it.name == "AdvancedScopedOrderDaoExtensions.kt" }.readText()
+    extContent shouldContain "field<String>(\"status\") notInList scopeValues"
+    extContent shouldContain "scopeValues.any { it.toString() == \"ARCHIVED\" }"
+    extContent shouldContain "field<String>(\"deletedAt\").isNull()"
+    extContent shouldContain "field<Long>(\"linkedId\").isNotNull()"
+  }
+
+  @Test
   fun `boolean scope property should be included in scope data class`() {
     val result = KotlinCompilation().apply {
       sources = listOf(
@@ -244,7 +273,7 @@ class ZygardeJpaDaoGeneratorTest {
   }
 
   @Test
-  fun `scope data class should wrap field type with Collection and provide convenience constructor`() {
+  fun `scope data class should use ScopeFilter and preserve collection and single-value constructors`() {
     val result = KotlinCompilation().apply {
       sources = listOf(
         ClassPathResource("codegen/jpa/TestGenerateScopedQuery.kt").file
@@ -261,15 +290,88 @@ class ZygardeJpaDaoGeneratorTest {
 
     val scopeContent = result.generatedFiles.first { it.name == "RegionalProductScope.kt" }.readText()
     scopeContent shouldContain "data class RegionalProductScope"
-    // Primary constructor should use Collection<Long>
+    // Primary constructor distinguishes All from Of(values).
+    scopeContent shouldContain "val regionId: ScopeFilter<Long>"
+    // Compatibility constructor should continue accepting Collection<Long>.
     scopeContent shouldContain "Collection<Long>"
     // Convenience constructor should accept single Long value
-    scopeContent shouldContain "listOf(regionId)"
+    scopeContent shouldContain "ScopeFilter.Of(listOf(regionId))"
 
     // Extension functions should use scope
     val extContent = result.generatedFiles.first { it.name == "RegionalProductDaoExtensions.kt" }.readText()
     extContent shouldContain "scope: RegionalProductScope"
-    extContent shouldContain "field<Long>(\"regionId\") inList scope.regionId"
+    extContent shouldContain "ScopeFilter.All -> Unit"
+    extContent shouldContain "val scopeValues = scopeFilter.values"
+    extContent shouldContain "field<Long>(\"regionId\") inList scopeValues"
+  }
+
+  @Test
+  fun `nullable scope constructors should resolve null without ambiguity`() {
+    val fixture = ClassPathResource("codegen/jpa/TestGenerateScopedQuery.kt").file
+    val generated = KotlinCompilation().apply {
+      sources = listOf(SourceFile.fromPath(fixture))
+      jvmTarget = JvmTarget.JVM_17.description
+      annotationProcessors = listOf(ZygardeJpaProcessor())
+      inheritClassPath = true
+    }.compile()
+    generated.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+    val result = KotlinCompilation().apply {
+      sources = listOf(SourceFile.fromPath(fixture)) +
+        generated.generatedFiles
+          .filter { it.name == "ScopedOrderScope.kt" || it.name == "AdvancedScopedOrderScope.kt" }
+          .map(SourceFile::fromPath) +
+        SourceFile.kotlin(
+          "ScopeConstructorUsage.kt",
+          """
+          package codegen.jpa
+
+          import zygarde.data.jpa.search.ScopeFilter
+          import zygarde.generated.data.dao.AdvancedScopedOrderScope
+          import zygarde.generated.data.dao.ScopedOrderScope
+
+          fun scopeConstructors() {
+            ScopedOrderScope()
+            ScopedOrderScope(platformSource = null)
+            ScopedOrderScope(null)
+            ScopedOrderScope(platformSource = ScopeFilter.All)
+            ScopedOrderScope(platformSource = emptyList())
+            ScopedOrderScope(platformSource = "HOTCAKE")
+            AdvancedScopedOrderScope()
+            AdvancedScopedOrderScope(status = null)
+            AdvancedScopedOrderScope(deletedAt = true)
+          }
+          """.trimIndent(),
+        )
+      jvmTarget = JvmTarget.JVM_17.description
+      inheritClassPath = true
+    }.compile()
+
+    result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+    result.messages shouldNotContain "Overload resolution ambiguity"
+  }
+
+  @Test
+  fun `scope data class should avoid constructors with the same erased JVM signature`() {
+    val result = KotlinCompilation().apply {
+      sources = listOf(
+        ClassPathResource("codegen/jpa/TestGenerateScopedQuery.kt").file
+      ).map { SourceFile.fromPath(it) }
+      jvmTarget = JvmTarget.JVM_17.description
+      annotationProcessors = listOf(ZygardeJpaProcessor())
+      inheritClassPath = true
+      messageOutputStream = System.out
+    }.compile()
+    result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+    val scopeContent = result.generatedFiles.first { it.name == "FilterValueEntityScope.kt" }.readText()
+    scopeContent shouldContain "val filter: ScopeFilter<ScopeFilter<String>>"
+    scopeContent shouldContain "filter: Collection<ScopeFilter<String>>"
+    scopeContent shouldNotContain "constructor(filter: ScopeFilter<String>)"
+
+    val collectionScopeContent = result.generatedFiles.first { it.name == "CollectionValueEntityScope.kt" }.readText()
+    collectionScopeContent shouldNotContain "constructor(values: Collection<String>)"
+    collectionScopeContent shouldNotContain "constructor(values: java.util.Collection<String>)"
   }
 
   @Test
@@ -318,7 +420,7 @@ class ZygardeJpaDaoGeneratorTest {
 
     val extContent = result.generatedFiles.first { it.name == "OwnedDocumentDaoExtensions.kt" }.readText()
     extContent shouldContain "scope: OwnedDocumentScope"
-    extContent shouldContain "field<Long>(\"ownerId\") inList scope.ownerId"
+    extContent shouldContain "field<Long>(\"ownerId\") inList scopeValues"
   }
 
   @Test
@@ -360,6 +462,11 @@ class ZygardeJpaDaoGeneratorTest {
 
     extContent shouldContain "fun ScopedOrderDao.remove("
     extContent shouldContain "scope: ScopedOrderScope"
+    val removeFunctions = extContent.split("fun ScopedOrderDao.remove(").drop(1)
+    removeFunctions.size shouldBe 2
+    removeFunctions.forEach { removeFunction ->
+      removeFunction shouldContain "): Long"
+    }
     val removeHead = extContent
       .substringAfter("fun ScopedOrderDao.remove(")
       .substringBefore(")")
@@ -367,6 +474,71 @@ class ZygardeJpaDaoGeneratorTest {
     val removeBody = extContent.substringAfter("fun ScopedOrderDao.remove(")
     removeBody shouldContain "originalSearchContent"
     removeBody shouldContain "delete(SearchSpecBuilder.buildSpec(searchContent))"
+  }
+
+  @Test
+  fun `missing scope should report an actionable compiler error`() {
+    val fixture = ClassPathResource("codegen/jpa/TestGenerateScopedQuery.kt").file
+    val generated = KotlinCompilation().apply {
+      sources = listOf(SourceFile.fromPath(fixture))
+      jvmTarget = JvmTarget.JVM_17.description
+      annotationProcessors = listOf(ZygardeJpaProcessor())
+      inheritClassPath = true
+      kaptArgs.put(ZygardeJpaCodegenKaptOptions.DAO_INHERIT, "zygarde.data.jpa.dao.ZygardeEnhancedDao")
+      kaptArgs.put(ZygardeJpaCodegenKaptOptions.DAO_COMBINE, "false")
+    }.compile()
+    generated.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+    val requiredGeneratedFiles = setOf(
+      "ScopedOrderDao.kt",
+      "ScopedOrderScope.kt",
+      "ScopedOrderDaoExtensions.kt",
+      "AdvancedScopedOrderScope.kt",
+    )
+    val result = KotlinCompilation().apply {
+      sources = listOf(SourceFile.fromPath(fixture)) +
+        generated.generatedFiles
+          .filter { it.name in requiredGeneratedFiles }
+          .map(SourceFile::fromPath) +
+        SourceFile.kotlin(
+          "MissingScopeUsage.kt",
+          """
+          package codegen.jpa
+
+          import zygarde.generated.data.dao.ScopedOrderDao
+          import zygarde.generated.data.dao.AdvancedScopedOrderScope
+          import zygarde.core.exception.CommonErrorCode
+          import zygarde.data.api.PagingAndSortingRequest
+          import zygarde.generated.data.dao.search
+          import zygarde.generated.data.dao.searchCount
+          import zygarde.generated.data.dao.searchOne
+          import zygarde.generated.data.dao.searchOneOrThrow
+          import zygarde.generated.data.dao.searchPage
+          import zygarde.generated.data.dao.remove
+
+          fun missingScope(dao: ScopedOrderDao) {
+            AdvancedScopedOrderScope()
+            AdvancedScopedOrderScope(deletedAt = true)
+            dao.search { field<String>("platformSource") eq "HOTCAKE" }
+            dao.search(sorts = null) { field<String>("platformSource") eq "HOTCAKE" }
+            dao.search(searchContent = { field<String>("platformSource") eq "HOTCAKE" }, limit = 1)
+            dao.searchCount { field<String>("platformSource") eq "HOTCAKE" }
+            dao.searchOne { field<String>("platformSource") eq "HOTCAKE" }
+            dao.searchOneOrThrow(CommonErrorCode.ERROR) { field<String>("platformSource") eq "HOTCAKE" }
+            dao.searchPage(PagingAndSortingRequest()) { field<String>("platformSource") eq "HOTCAKE" }
+            dao.remove { field<String>("platformSource") eq "HOTCAKE" }
+          }
+          """.trimIndent(),
+        )
+      jvmTarget = JvmTarget.JVM_17.description
+      inheritClassPath = true
+    }.compile()
+
+    result.exitCode shouldBe KotlinCompilation.ExitCode.COMPILATION_ERROR
+    result.messages shouldContain "請以第一參數傳入 ScopedOrderScope"
+    result.messages shouldContain "ScopedOrderScope(platformSource = ScopeFilter.All)"
+    result.messages shouldNotContain "Overload resolution ambiguity"
+    result.messages shouldNotContain "Unresolved reference: field"
   }
 
   @Test

--- a/modules-jpa/zygarde-jpa-codegen/src/test/resources/codegen/jpa/TestGenerateScopedQuery.kt
+++ b/modules-jpa/zygarde-jpa-codegen/src/test/resources/codegen/jpa/TestGenerateScopedQuery.kt
@@ -2,7 +2,10 @@ package codegen.jpa
 
 import zygarde.codegen.NullEquivalent
 import zygarde.codegen.ScopeMarker
+import zygarde.codegen.ScopeOp
+import zygarde.codegen.ScopeOperator
 import zygarde.codegen.ZyModel
+import zygarde.data.jpa.search.ScopeFilter
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 
@@ -22,6 +25,29 @@ interface FeatureToggleScoped {
   val enabled: Boolean
 }
 
+@ScopeMarker
+interface AdvancedScopedEntity {
+  @get:NullEquivalent("ARCHIVED")
+  @get:ScopeOp(ScopeOperator.NOT_IN)
+  val status: String?
+
+  @get:ScopeOp(ScopeOperator.IS_NULL)
+  val deletedAt: String?
+
+  @get:ScopeOp(ScopeOperator.IS_NOT_NULL)
+  val linkedId: Long?
+}
+
+@ScopeMarker
+interface FilterValueScoped {
+  val filter: ScopeFilter<String>
+}
+
+@ScopeMarker
+interface CollectionValueScoped {
+  val values: Collection<String>
+}
+
 @ZyModel
 @Entity
 class ScopedOrder(
@@ -38,6 +64,32 @@ class MultiScopedOrder(
   override val platformSource: String? = null,
   override val tenantId: String = "",
 ) : PlatformScopedEntity, TenantScopedEntity
+
+@ZyModel
+@Entity
+class AdvancedScopedOrder(
+  @Id
+  var id: Long,
+  override val status: String? = null,
+  override val deletedAt: String? = null,
+  override val linkedId: Long? = null,
+) : AdvancedScopedEntity
+
+@ZyModel
+@Entity
+class FilterValueEntity(
+  @Id
+  var id: Long,
+  override val filter: ScopeFilter<String> = ScopeFilter.All,
+) : FilterValueScoped
+
+@ZyModel
+@Entity
+class CollectionValueEntity(
+  @Id
+  var id: Long,
+  override val values: Collection<String> = emptyList(),
+) : CollectionValueScoped
 
 @ScopeMarker
 interface RegionScoped {

--- a/modules-jpa/zygarde-jpa/src/main/kotlin/zygarde/codegen/NullEquivalent.kt
+++ b/modules-jpa/zygarde-jpa/src/main/kotlin/zygarde/codegen/NullEquivalent.kt
@@ -23,6 +23,6 @@ package zygarde.codegen
  *
  * @param value the sentinel value that triggers OR IS NULL behavior
  */
-@Target(AnnotationTarget.PROPERTY, AnnotationTarget.PROPERTY_GETTER)
+@Target(AnnotationTarget.PROPERTY_GETTER)
 @Retention(AnnotationRetention.BINARY)
 annotation class NullEquivalent(val value: String)

--- a/modules-jpa/zygarde-jpa/src/main/kotlin/zygarde/codegen/ScopeMarker.kt
+++ b/modules-jpa/zygarde-jpa/src/main/kotlin/zygarde/codegen/ScopeMarker.kt
@@ -7,7 +7,7 @@ package zygarde.codegen
  * the code generator:
  * 1. Generates a `{Entity}Scope` data class from all scope interface properties
  * 2. Generates scoped extension functions (search, remove, etc.) that require a scope parameter
- * 3. Does NOT generate unscoped overloads — compiler enforces scoping
+ * 3. Generates error-deprecated unscoped placeholders so the compiler explains how to pass the required scope
  *
  * ```
  * @ScopeMarker
@@ -22,7 +22,9 @@ package zygarde.codegen
  * ) : PlatformScopedEntity
  *
  * // Generated: OrderScope data class + scoped extension functions
+ * // Scalar and collection constructors wrap values in ScopeFilter.Of.
  * // orderDao.search(OrderScope(platformSource = "HOTCAKE")) { ... }
+ * // Use ScopeFilter.All when a required scope field intentionally should not filter.
  * ```
  */
 @Target(AnnotationTarget.CLASS)

--- a/modules-jpa/zygarde-jpa/src/main/kotlin/zygarde/codegen/ScopeOp.kt
+++ b/modules-jpa/zygarde-jpa/src/main/kotlin/zygarde/codegen/ScopeOp.kt
@@ -1,0 +1,20 @@
+package zygarde.codegen
+
+/**
+ * Selects the predicate generated for a scoped entity property.
+ *
+ * [IS_NULL] and [IS_NOT_NULL] generate a Boolean scope field. `true` applies
+ * the null check; `false` (or `null` for an optional scope field) skips it.
+ * [NullEquivalent] only affects [IN] and [NOT_IN]. For [NOT_IN], excluding the
+ * sentinel also excludes SQL NULL; otherwise SQL NULL remains included.
+ */
+@Target(AnnotationTarget.PROPERTY_GETTER)
+@Retention(AnnotationRetention.BINARY)
+annotation class ScopeOp(val value: ScopeOperator = ScopeOperator.IN)
+
+enum class ScopeOperator {
+  IN,
+  NOT_IN,
+  IS_NULL,
+  IS_NOT_NULL,
+}

--- a/modules-jpa/zygarde-jpa/src/main/kotlin/zygarde/data/jpa/search/ScopeFilter.kt
+++ b/modules-jpa/zygarde-jpa/src/main/kotlin/zygarde/data/jpa/search/ScopeFilter.kt
@@ -1,0 +1,10 @@
+package zygarde.data.jpa.search
+
+/** A scoped-query filter that distinguishes an explicit bypass from a value set. */
+sealed interface ScopeFilter<out T> {
+  /** Do not add a predicate for this scope field. */
+  data object All : ScopeFilter<Nothing>
+
+  /** Match this value set. An empty set intentionally matches nothing. */
+  data class Of<T>(val values: Collection<T>) : ScopeFilter<T>
+}

--- a/modules-jpa/zygarde-jpa/src/main/kotlin/zygarde/data/jpa/search/action/ConditionAction.kt
+++ b/modules-jpa/zygarde-jpa/src/main/kotlin/zygarde/data/jpa/search/action/ConditionAction.kt
@@ -38,6 +38,15 @@ interface ConditionAction<RootEntityType, EntityType, FieldType> {
 
   infix fun inList(values: Collection<FieldType>?): EnhancedSearch<RootEntityType>
 
+  /** Like [inList], except that an empty collection matches nothing. A null value is still ignored. */
+  infix fun inListStrict(values: Collection<FieldType>?): EnhancedSearch<RootEntityType> =
+    if (values?.isEmpty() == true) {
+      isNull()
+      isNotNull()
+    } else {
+      inList(values)
+    }
+
   infix fun notInList(values: Collection<FieldType>?): EnhancedSearch<RootEntityType>
 
   infix fun eq(anotherAction: ConditionAction<*, *, FieldType>)

--- a/modules-jpa/zygarde-jpa/src/main/kotlin/zygarde/data/jpa/search/action/impl/ConditionActionImpl.kt
+++ b/modules-jpa/zygarde-jpa/src/main/kotlin/zygarde/data/jpa/search/action/impl/ConditionActionImpl.kt
@@ -101,6 +101,13 @@ open class ConditionActionImpl<RootEntityType, EntityType, FieldType>(
       }
     }
 
+  override fun inListStrict(values: Collection<FieldType>?): EnhancedSearch<RootEntityType> =
+    if (values?.isEmpty() == true) {
+      enhancedSearch.apply { predicates.add(cb.disjunction()) }
+    } else {
+      inList(values)
+    }
+
   override fun notInList(values: Collection<FieldType>?): EnhancedSearch<RootEntityType> =
     applyNonNullAction(values?.takeIf { it.isNotEmpty() }) { path, v ->
       if (v.size > 500) {

--- a/modules-jpa/zygarde-jpa/src/test/kotlin/zygarde/test/EnhancedSearchTest.kt
+++ b/modules-jpa/zygarde-jpa/src/test/kotlin/zygarde/test/EnhancedSearchTest.kt
@@ -133,6 +133,7 @@ class EnhancedSearchTest {
   fun `should ignore search condition`() {
     bookDao.search { stringField("name") inList null }.size shouldBe 1000
     bookDao.search { stringField("name") inList emptyList() }.size shouldBe 1000
+    bookDao.search { stringField("name") inListStrict null }.size shouldBe 1000
     bookDao.search { stringField("name") notInList null }.size shouldBe 1000
     bookDao.search { stringField("name") notInList emptyList() }.size shouldBe 1000
     bookDao.search { stringField("name") eq null }.size shouldBe 1000
@@ -143,6 +144,13 @@ class EnhancedSearchTest {
     bookDao.search { field<Author>("author").comparableField<String>("name") inList emptyList() }.size shouldBe 1000
     bookDao.search { field<Author>("author").field<LocalDate>("registerDate") eq null }.size shouldBe 1000
     bookDao.search { rangeOverlap({ field(Book::minPrice) }, { field(Book::maxPrice) }, SearchIntRangeOverlap(0, 1000)) }.size shouldBe 1000
+  }
+
+  @Order(350)
+  @Test
+  fun `inListStrict should match nothing for an empty collection`() {
+    bookDao.search { stringField("name") inListStrict emptyList() }.size shouldBe 0
+    bookDao.search { stringField("name") inListStrict listOf("zygarde") }.size shouldBe 20
   }
 
   @Order(400)

--- a/samples/todo-ksp/src/main/kotlin/zygarde/samples/todo/Note.kt
+++ b/samples/todo-ksp/src/main/kotlin/zygarde/samples/todo/Note.kt
@@ -2,6 +2,8 @@ package zygarde.samples.todo
 
 import zygarde.codegen.NullEquivalent
 import zygarde.codegen.ScopeMarker
+import zygarde.codegen.ScopeOp
+import zygarde.codegen.ScopeOperator
 import zygarde.codegen.ZyModel
 import zygarde.data.jpa.entity.AutoLongIdEntity
 import jakarta.persistence.Entity
@@ -24,3 +26,36 @@ class Note(
   override var tenantId: String = "",
   override var visibility: String? = null,
 ) : AutoLongIdEntity(), TenantScoped, VisibilityScoped
+
+enum class ScopedTaskStatus {
+  ACTIVE,
+  CANCELLED,
+  ARCHIVED,
+}
+
+@ScopeMarker
+interface ScopedTaskFilters {
+  @get:NullEquivalent("ARCHIVED")
+  @get:ScopeOp(ScopeOperator.NOT_IN)
+  val status: ScopedTaskStatus?
+
+  @get:NullEquivalent("ARCHIVED-CODE")
+  @get:ScopeOp(ScopeOperator.NOT_IN)
+  val excludedCode: String?
+
+  @get:ScopeOp(ScopeOperator.IS_NULL)
+  val deletedAt: String?
+
+  @get:ScopeOp(ScopeOperator.IS_NOT_NULL)
+  val linkedId: Long?
+}
+
+@ZyModel
+@Entity
+class ScopedTask(
+  var name: String = "",
+  override var status: ScopedTaskStatus? = null,
+  override var excludedCode: String? = null,
+  override var deletedAt: String? = null,
+  override var linkedId: Long? = null,
+) : AutoLongIdEntity(), ScopedTaskFilters

--- a/samples/todo-ksp/src/test/kotlin/zygarde/samples/todo/NoteScopedQueryTest.kt
+++ b/samples/todo-ksp/src/test/kotlin/zygarde/samples/todo/NoteScopedQueryTest.kt
@@ -14,8 +14,11 @@ import zygarde.core.exception.BusinessException
 import zygarde.data.api.PagingAndSortingRequest
 import zygarde.data.api.PagingRequest
 import zygarde.data.api.SortField
+import zygarde.data.jpa.search.ScopeFilter
 import zygarde.samples.todo.generated.dao.NoteDao
 import zygarde.samples.todo.generated.dao.NoteScope
+import zygarde.samples.todo.generated.dao.ScopedTaskDao
+import zygarde.samples.todo.generated.dao.ScopedTaskScope
 import zygarde.samples.todo.generated.dao.search
 import zygarde.samples.todo.generated.dao.searchCount
 import zygarde.samples.todo.generated.dao.searchOne
@@ -37,9 +40,13 @@ class NoteScopedQueryTest {
   @Autowired
   lateinit var noteDao: NoteDao
 
+  @Autowired
+  lateinit var scopedTaskDao: ScopedTaskDao
+
   @BeforeEach
   fun setUp() {
     noteDao.deleteAll()
+    scopedTaskDao.deleteAll()
     noteDao.saveAll(
       listOf(
         Note(title = "t1-public", tenantId = "t1", visibility = "PUBLIC"),
@@ -47,6 +54,14 @@ class NoteScopedQueryTest {
         Note(title = "t1-null", tenantId = "t1", visibility = null),
         Note(title = "t2-public", tenantId = "t2", visibility = "PUBLIC"),
         Note(title = "t2-null", tenantId = "t2", visibility = null),
+      )
+    )
+    scopedTaskDao.saveAll(
+      listOf(
+        ScopedTask(name = "active", status = ScopedTaskStatus.ACTIVE, excludedCode = "ACTIVE-CODE", linkedId = 1),
+        ScopedTask(name = "cancelled", status = ScopedTaskStatus.CANCELLED, excludedCode = "CANCELLED-CODE", deletedAt = "deleted"),
+        ScopedTask(name = "archived", status = ScopedTaskStatus.ARCHIVED, excludedCode = "ARCHIVED-CODE", linkedId = 2),
+        ScopedTask(name = "null-status", status = null, excludedCode = null, deletedAt = "deleted"),
       )
     )
   }
@@ -65,12 +80,15 @@ class NoteScopedQueryTest {
   }
 
   @Test
-  fun `empty collection on a scope field is treated as no-filter`() {
-    // Guardrail against a subtle gotcha: inList silently drops empty collections
-    // (see ConditionActionImpl.inList), so an empty scope collection returns ALL
-    // records for that field rather than zero. Callers expecting strict matching
-    // must pre-check emptiness themselves.
+  fun `empty collection on a scope field matches nothing`() {
     val results = noteDao.search(NoteScope(tenantId = emptyList()))
+    results shouldHaveSize 0
+  }
+
+  @Test
+  fun `ScopeFilter All explicitly skips a required scope predicate`() {
+    val results = noteDao.search(NoteScope(tenantId = ScopeFilter.All))
+
     results shouldHaveSize 5
   }
 
@@ -142,5 +160,70 @@ class NoteScopedQueryTest {
     }
 
     results.map { it.title } shouldContainExactlyInAnyOrder listOf("t1-public", "t1-private")
+  }
+
+  @Test
+  fun `NOT_IN excludes enum values and preserves null when sentinel is not excluded`() {
+    val results = scopedTaskDao.search(ScopedTaskScope(status = listOf(ScopedTaskStatus.CANCELLED)))
+
+    results.map { it.name } shouldContainExactlyInAnyOrder listOf("active", "archived", "null-status")
+  }
+
+  @Test
+  fun `NOT_IN with an empty scoped value set matches nothing`() {
+    scopedTaskDao.search(ScopedTaskScope(status = emptyList())) shouldHaveSize 0
+  }
+
+  @Test
+  fun `NOT_IN excludes null when NullEquivalent sentinel is excluded`() {
+    val results = scopedTaskDao.search(ScopedTaskScope(status = listOf(ScopedTaskStatus.ARCHIVED)))
+
+    results.map { it.name } shouldContainExactlyInAnyOrder listOf("active", "cancelled")
+  }
+
+  @Test
+  fun `NOT_IN supports enum complement without omitting future enum values`() {
+    val excluded = ScopedTaskStatus.entries - ScopedTaskStatus.ACTIVE
+    val results = scopedTaskDao.search(ScopedTaskScope(status = excluded))
+
+    results.map { it.name } shouldContainExactlyInAnyOrder listOf("active")
+  }
+
+  @Test
+  fun `IS_NULL and IS_NOT_NULL apply only when enabled`() {
+    scopedTaskDao.search(ScopedTaskScope(deletedAt = true))
+      .map { it.name } shouldContainExactlyInAnyOrder listOf("active", "archived")
+    scopedTaskDao.search(ScopedTaskScope(linkedId = true))
+      .map { it.name } shouldContainExactlyInAnyOrder listOf("active", "archived")
+    scopedTaskDao.search(ScopedTaskScope(deletedAt = false, linkedId = false)) shouldHaveSize 4
+  }
+
+  @Test
+  fun `IN keeps matches when values cross the 500-value chunk boundary`() {
+    val tenantIds = (0 until 500).map { "missing-$it" } + "t1"
+
+    noteDao.search(NoteScope(tenantId = tenantIds))
+      .map { it.title } shouldContainExactlyInAnyOrder listOf("t1-public", "t1-private", "t1-null")
+  }
+
+  @Test
+  fun `IN finds NullEquivalent sentinel across the 500-value chunk boundary`() {
+    val visibilities = (0 until 500).map { "missing-$it" } + "PUBLIC"
+
+    noteDao.search(
+      NoteScope(
+        tenantId = ScopeFilter.Of(listOf("t1")),
+        visibility = ScopeFilter.Of(visibilities),
+      )
+    )
+      .map { it.title } shouldContainExactlyInAnyOrder listOf("t1-public", "t1-null")
+  }
+
+  @Test
+  fun `NOT_IN combines chunks with AND and handles a sentinel in the final chunk`() {
+    val excludedCodes = (0 until 500).map { "missing-$it" } + "ARCHIVED-CODE"
+
+    scopedTaskDao.search(ScopedTaskScope(status = null, excludedCode = excludedCodes))
+      .map { it.name } shouldContainExactlyInAnyOrder listOf("active", "cancelled")
   }
 }

--- a/samples/todo-legacy/build.gradle.kts
+++ b/samples/todo-legacy/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.springframework.boot:spring-boot-starter-web")
   implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+  runtimeOnly("com.h2database:h2")
+  testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 
 tasks.getByName("bootJar").enabled = false

--- a/samples/todo-legacy/src/main/kotlin/example/TodoDemo.kt
+++ b/samples/todo-legacy/src/main/kotlin/example/TodoDemo.kt
@@ -1,6 +1,9 @@
 package example
 
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 import org.springframework.stereotype.Service
 import org.springframework.web.bind.annotation.RequestMethod
 import zygarde.codegen.AdditionalDtoProp
@@ -9,15 +12,20 @@ import zygarde.codegen.ApiPathVariable
 import zygarde.codegen.ApiProp
 import zygarde.codegen.Dto
 import zygarde.codegen.GenApi
+import zygarde.codegen.NullEquivalent
 import zygarde.codegen.RequestDto
+import zygarde.codegen.ScopeMarker
+import zygarde.codegen.ScopeOp
+import zygarde.codegen.ScopeOperator
 import zygarde.codegen.StaticOptionApi
 import zygarde.codegen.ZyApi
 import zygarde.codegen.ZyModel
 import zygarde.codegen.value.AutoIntIdValueProvider
-import zygarde.generated.data.dao.search
 import zygarde.data.jpa.entity.AutoIntIdEntity
+import zygarde.data.jpa.entity.AutoLongIdEntity
 import zygarde.data.option.OptionEnum
 import zygarde.generated.data.dao.TodoDao
+import zygarde.generated.data.dao.search
 import zygarde.generated.data.dto.CreateToDoReq
 import zygarde.generated.data.dto.TodoDto
 import zygarde.generated.data.dto.UpdateToDoReq
@@ -31,6 +39,28 @@ import jakarta.persistence.Entity
 const val createToDoReq = "CreateToDoReq"
 const val updateToDoReq = "UpdateToDoReq"
 const val todoDto = "TodoDto"
+
+@SpringBootApplication
+@EntityScan("example")
+@EnableJpaRepositories("zygarde.generated.data.dao")
+class TodoLegacyApplication
+
+@ScopeMarker
+interface LegacyScoped {
+  val tenantId: String
+
+  @get:NullEquivalent("NULL-CODE")
+  @get:ScopeOp(ScopeOperator.NOT_IN)
+  val excludedCode: String?
+}
+
+@ZyModel
+@Entity
+class LegacyScopedRecord(
+  var label: String = "",
+  override var tenantId: String = "",
+  override var excludedCode: String? = null,
+) : AutoLongIdEntity(), LegacyScoped
 
 @ZyModel
 @Entity

--- a/samples/todo-legacy/src/test/kotlin/example/LegacyScopedQueryTest.kt
+++ b/samples/todo-legacy/src/test/kotlin/example/LegacyScopedQueryTest.kt
@@ -1,0 +1,61 @@
+package example
+
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import zygarde.data.jpa.search.ScopeFilter
+import zygarde.generated.data.dao.LegacyScopedRecordDao
+import zygarde.generated.data.dao.LegacyScopedRecordScope
+import zygarde.generated.data.dao.search
+
+@DataJpaTest
+@AutoConfigureTestDatabase
+class LegacyScopedQueryTest {
+  @Autowired
+  lateinit var dao: LegacyScopedRecordDao
+
+  @BeforeEach
+  fun setUp() {
+    dao.deleteAll()
+    dao.saveAll(
+      listOf(
+        LegacyScopedRecord(label = "t1-active", tenantId = "t1", excludedCode = "ACTIVE"),
+        LegacyScopedRecord(label = "t1-blocked", tenantId = "t1", excludedCode = "BLOCKED"),
+        LegacyScopedRecord(label = "t1-null", tenantId = "t1", excludedCode = null),
+        LegacyScopedRecord(label = "t2-active", tenantId = "t2", excludedCode = "ACTIVE"),
+      )
+    )
+  }
+
+  @Test
+  fun `KAPT generated scope filters against H2`() {
+    dao.search(LegacyScopedRecordScope(tenantId = "t1"))
+      .map { it.label } shouldContainExactlyInAnyOrder listOf("t1-active", "t1-blocked", "t1-null")
+  }
+
+  @Test
+  fun `KAPT generated empty scope collection matches nothing`() {
+    dao.search(LegacyScopedRecordScope(tenantId = emptyList())) shouldHaveSize 0
+  }
+
+  @Test
+  fun `KAPT generated NOT_IN preserves or excludes null according to sentinel`() {
+    dao.search(
+      LegacyScopedRecordScope(
+        tenantId = ScopeFilter.Of(listOf("t1")),
+        excludedCode = ScopeFilter.Of(listOf("BLOCKED")),
+      )
+    ).map { it.label } shouldContainExactlyInAnyOrder listOf("t1-active", "t1-null")
+
+    dao.search(
+      LegacyScopedRecordScope(
+        tenantId = ScopeFilter.Of(listOf("t1")),
+        excludedCode = ScopeFilter.Of(listOf("NULL-CODE")),
+      )
+    ).map { it.label } shouldContainExactlyInAnyOrder listOf("t1-active", "t1-blocked")
+  }
+}


### PR DESCRIPTION
## Summary

- add per-property scope operators for `IN`, `NOT_IN`, `IS_NULL`, and `IS_NOT_NULL`
- introduce typed `ScopeFilter` values so `All` and an empty match set are distinct
- make `ScopeFilter.Of(emptyList())` match nothing while preserving the existing `inList(emptyList())` behavior
- add opt-in `inListStrict` semantics for non-scope search DSL calls
- generate actionable compile errors when scoped DAO calls omit scope
- keep KAPT and KSP generation behavior aligned on the v3 / Spring Boot 3 / Jakarta baseline

## Downstream validation

Validated against the `hunger_api3` codebase using the same compile-error measurement for its 3.0.3 baseline and this PR:

| Metric | 3.0.3 baseline | PR25 |
|---|---:|---:|
| Compiler diagnostics / log lines | 433 / 11,378 | 95 / 227 |
| Readable diagnostics naming scope and a fix | 9.9% | 100% |
| Real missing-scope call sites surfaced | 43/95 | 95/95 |
| Lambda receiver type-collapse diagnostics | 89 | 0 |

The generated constructors were also stress-tested with seven invocation forms and produced zero ambiguity. `NOT_IN` directly expresses canonical exclusion sets, avoiding enum-complement code that can silently miss newly added values.

## Compatibility and migration

Generated membership properties now use `ScopeFilter<T>`, which changes generated constructors, getters, `componentN`, `copy`, and their JVM signatures. Regenerate scopes and recompile consumers together. Existing scalar and collection constructor calls remain source-compatible; choose the actual scope first and use `ScopeFilter.All` only for an intentional, explicit bypass.

Spring Data native DAO methods remain outside the generated ScopedQueries enforcement boundary. ScopedQueries should not be treated as an authorization or tenant-isolation boundary by itself.

This PR now targets v3, so generated `remove` functions and missing-scope placeholders follow the v3 DAO contract and return `Long`; both KAPT and KSP have regression coverage for this signature.

## Verification

- `./gradlew test`
- targeted KAPT and KSP scoped-`remove` codegen tests
- KAPT and KSP H2 runtime tests, including empty collections, `NullEquivalent`, `NOT_IN`, enum complements, and 501-value chunk boundaries
- `ktlintCheck` for affected codegen and sample modules
- `git diff --check`