### PR TITLE
feat(sql-api): add AST validation rules

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added SQL API codegen validation rules with access to the parsed JSqlParser AST for queries, page count queries, and commands.
+
 ## [3.1.0] - 2026-05-29
 
 ### Added

--- a/docs/guide/sql-api.md
+++ b/docs/guide/sql-api.md
@@ -416,6 +416,36 @@ The DSL validates common mismatches before writing generated files:
 - Paged query count SQL must select the configured count column.
 - Main SQL and count SQL share the same declared parameter set, including context parameters.
 
+### Custom AST validation
+
+Codegen projects can register validation rules for project-specific SQL policies. Each rule receives the original SQL and
+the JSqlParser 5.0 `Statement` after built-in metadata extraction. Rules apply to main query SQL, page count SQL, and
+`INSERT`, `UPDATE`, and `DELETE` commands.
+
+```kotlin
+class TodoSqlApiCodegen : SqlApiDslCodegen() {
+  override val sqlValidationRules = listOf(
+    SqlValidationRule { _, statement ->
+      if (statement is Delete && statement.where == null) {
+        listOf("DELETE statements must declare a WHERE clause")
+      } else {
+        emptyList()
+      }
+    },
+  )
+
+  override fun codegen() {
+    // SQL API declarations
+  }
+}
+```
+
+Rules run synchronously in declaration order and findings are reported together with the API, function, and SQL role.
+The JSqlParser AST is mutable, but validation rules must treat it as read-only. Rules inspecting nested CTEs, set
+operations, or expression subqueries are responsible for traversing those nodes, typically with JSqlParser visitors.
+The original SQL should be used for comment-based exemption markers because comments and named parameters are not
+guaranteed to round-trip through the parsed AST.
+
 ## See Also
 
 - [Web & REST APIs](web-rest.md)

--- a/modules-web/zygarde-sql-api-codegen-dsl/build.gradle.kts
+++ b/modules-web/zygarde-sql-api-codegen-dsl/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
   implementation(project(":zygarde-webmvc"))
   implementation("io.github.classgraph:classgraph")
   implementation("com.squareup:kotlinpoet")
-  implementation("com.github.jsqlparser:jsqlparser:5.0")
+  api("com.github.jsqlparser:jsqlparser:5.0")
   implementation("org.springframework.boot:spring-boot-starter-web")
 
   testImplementation(platform(project(":zygarde-bom-codegen-test")))

--- a/modules-web/zygarde-sql-api-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/sqlapi/DslSqlApi.kt
+++ b/modules-web/zygarde-sql-api-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/sqlapi/DslSqlApi.kt
@@ -5,10 +5,20 @@ class DslSqlApi(
   private val apiName: String,
   private val basePath: String,
 ) {
+  private var sqlValidationRules: List<SqlValidationRule> = emptyList()
   private val queries: MutableList<SqlQueryToGenerateVo> = mutableListOf()
   private val commands: MutableList<SqlCommandToGenerateVo> = mutableListOf()
   private var database: SqlApiDatabaseToGenerateVo = SqlApiDatabaseToGenerateVo()
   private var transactionPolicy: SqlApiTransactionPolicy? = null
+
+  internal constructor(
+    config: SqlApiDslCodegenConfig,
+    apiName: String,
+    basePath: String,
+    sqlValidationRules: List<SqlValidationRule>,
+  ) : this(config, apiName, basePath) {
+    this.sqlValidationRules = sqlValidationRules
+  }
 
   fun database(dsl: DslSqlDatabase.() -> Unit) {
     database = DslSqlDatabase().also(dsl).toSqlApiDatabaseToGenerateVo()
@@ -27,11 +37,11 @@ class DslSqlApi(
   }
 
   fun query(functionName: String, path: String, dsl: DslSqlQuery.() -> Unit) {
-    queries.add(DslSqlQuery(functionName, path).also(dsl).toSqlQueryToGenerateVo())
+    queries.add(DslSqlQuery(functionName, path).also(dsl).toSqlQueryToGenerateVo(apiName, sqlValidationRules))
   }
 
   fun command(functionName: String, path: String, dsl: DslSqlCommand.() -> Unit) {
-    commands.add(DslSqlCommand(functionName, path).also(dsl).toSqlCommandToGenerateVo())
+    commands.add(DslSqlCommand(functionName, path).also(dsl).toSqlCommandToGenerateVo(apiName, sqlValidationRules))
   }
 
   fun toSqlApiToGenerateVo(): SqlApiToGenerateVo {

--- a/modules-web/zygarde-sql-api-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/sqlapi/DslSqlCommand.kt
+++ b/modules-web/zygarde-sql-api-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/sqlapi/DslSqlCommand.kt
@@ -133,8 +133,16 @@ class DslSqlCommand(
   }
 
   fun toSqlCommandToGenerateVo(): SqlCommandToGenerateVo {
+    return toSqlCommandToGenerateVo(apiName = null, sqlValidationRules = emptyList())
+  }
+
+  internal fun toSqlCommandToGenerateVo(
+    apiName: String?,
+    sqlValidationRules: List<SqlValidationRule>,
+  ): SqlCommandToGenerateVo {
     val sql = requireNotNull(sqlLiteral) { "SQL is required for command '$functionName'" }
-    val metadata = SqlCommandParser.parse(sql)
+    val parsedSql = SqlCommandParser.parseForValidation(sql)
+    val metadata = parsedSql.metadata
     val generatedKey = generatedKey
     if (resultShape == SqlCommandResultShape.GENERATED_KEY) {
       requireNotNull(generatedKey) { "Generated key configuration is required for command '$functionName'" }
@@ -152,6 +160,15 @@ class DslSqlCommand(
     }
     validateBodyParams(params)
     validatePathParams(params)
+    if (apiName != null && sqlValidationRules.isNotEmpty()) {
+      validateSqlStatements(
+        apiName = apiName,
+        declarationKind = "command",
+        functionName = functionName,
+        rules = sqlValidationRules,
+        statements = listOf(SqlStatementToValidate("command SQL", sql, parsedSql.statement)),
+      )
+    }
 
     return SqlCommandToGenerateVo(
       functionName = functionName,

--- a/modules-web/zygarde-sql-api-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/sqlapi/DslSqlQuery.kt
+++ b/modules-web/zygarde-sql-api-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/sqlapi/DslSqlQuery.kt
@@ -151,10 +151,19 @@ class DslSqlQuery(
   }
 
   fun toSqlQueryToGenerateVo(): SqlQueryToGenerateVo {
+    return toSqlQueryToGenerateVo(apiName = null, sqlValidationRules = emptyList())
+  }
+
+  internal fun toSqlQueryToGenerateVo(
+    apiName: String?,
+    sqlValidationRules: List<SqlValidationRule>,
+  ): SqlQueryToGenerateVo {
     val sql = requireNotNull(sqlLiteral) { "SQL is required for query '$functionName'" }
-    val metadata = SqlSelectParser.parse(sql)
+    val parsedSql = SqlSelectParser.parseForValidation(sql)
+    val metadata = parsedSql.metadata
     val page = page
-    val countMetadata = page?.let { SqlSelectParser.parse(it.countSql) }
+    val parsedCountSql = page?.let { SqlSelectParser.parseForValidation(it.countSql) }
+    val countMetadata = parsedCountSql?.metadata
     if (resultShape == SqlQueryResultShape.PAGE) {
       requireNotNull(page) { "Page SQL configuration is required for query '$functionName'" }
       require(metadata.parameterNames.contains(page.offsetParamName)) {
@@ -213,6 +222,20 @@ class DslSqlQuery(
     }
     require(columns.isNotEmpty()) {
       "SQL query '$functionName' must declare at least one output column or use SELECT expressions with AS aliases"
+    }
+    if (apiName != null && sqlValidationRules.isNotEmpty()) {
+      validateSqlStatements(
+        apiName = apiName,
+        declarationKind = "query",
+        functionName = functionName,
+        rules = sqlValidationRules,
+        statements = buildList {
+          add(SqlStatementToValidate("main SQL", sql, parsedSql.statement))
+          if (page != null && parsedCountSql != null) {
+            add(SqlStatementToValidate("count SQL", page.countSql, parsedCountSql.statement))
+          }
+        },
+      )
     }
 
     return SqlQueryToGenerateVo(

--- a/modules-web/zygarde-sql-api-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/sqlapi/SqlApiDslCodegen.kt
+++ b/modules-web/zygarde-sql-api-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/sqlapi/SqlApiDslCodegen.kt
@@ -11,10 +11,13 @@ abstract class SqlApiDslCodegen {
 
   val apisToGenerate: MutableList<SqlApiToGenerateVo> = mutableListOf()
 
+  protected open val sqlValidationRules: List<SqlValidationRule>
+    get() = emptyList()
+
   abstract fun codegen()
 
   protected fun sqlApi(apiName: String, basePath: String, dsl: DslSqlApi.() -> Unit) {
-    val dslApi = DslSqlApi(config, apiName, basePath).also(dsl)
+    val dslApi = DslSqlApi(config, apiName, basePath, sqlValidationRules.toList()).also(dsl)
     apisToGenerate.add(dslApi.toSqlApiToGenerateVo())
   }
 }

--- a/modules-web/zygarde-sql-api-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/sqlapi/SqlCommandParser.kt
+++ b/modules-web/zygarde-sql-api-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/sqlapi/SqlCommandParser.kt
@@ -19,27 +19,34 @@ enum class SqlCommandKind {
 
 object SqlCommandParser {
   fun parse(sql: String): SqlCommandMetadata {
-    val parsedSql = NamedParameterSql.parse(sql)
-    val kind = parseKind(parsedSql.sql)
+    return parseForValidation(sql).metadata
+  }
 
-    return SqlCommandMetadata(
-      parameterNames = parsedSql.parameterNames.distinct(),
-      kind = kind,
+  internal fun parseForValidation(sql: String): ParsedSql<SqlCommandMetadata> {
+    val parsedSql = NamedParameterSql.parse(sql)
+    val statement = parseStatement(parsedSql.sql)
+    val kind = when (statement) {
+      is Insert -> SqlCommandKind.INSERT
+      is Update -> SqlCommandKind.UPDATE
+      is Delete -> SqlCommandKind.DELETE
+      else -> throw IllegalArgumentException("SQL API command only supports INSERT, UPDATE, and DELETE statements")
+    }
+
+    return ParsedSql(
+      metadata = SqlCommandMetadata(
+        parameterNames = parsedSql.parameterNames.distinct(),
+        kind = kind,
+      ),
+      statement = statement,
     )
   }
 
-  private fun parseKind(sql: String): SqlCommandKind {
-    return try {
-      when (CCJSqlParserUtil.parse(sql)) {
-        is Insert -> SqlCommandKind.INSERT
-        is Update -> SqlCommandKind.UPDATE
-        is Delete -> SqlCommandKind.DELETE
-        else -> throw IllegalArgumentException("SQL API command only supports INSERT, UPDATE, and DELETE statements")
-      }
+  private fun parseStatement(sql: String) =
+    try {
+      CCJSqlParserUtil.parse(sql)
     } catch (e: IllegalArgumentException) {
       throw e
     } catch (e: Exception) {
       throw IllegalArgumentException("Failed to parse SQL command: ${e.message}", e)
     }
-  }
 }

--- a/modules-web/zygarde-sql-api-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/sqlapi/SqlSelectParser.kt
+++ b/modules-web/zygarde-sql-api-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/sqlapi/SqlSelectParser.kt
@@ -15,22 +15,39 @@ object SqlSelectParser {
   private val kotlinPropertyNameRegex = Regex("""[A-Za-z_][A-Za-z0-9_]*""")
 
   fun parse(sql: String): SqlSelectMetadata {
-    val parameterNames = NamedParameterSql.parse(sql).parameterNames.distinct()
-    val columnAliases = parseOutputColumns(sql)
+    return parseForValidation(sql).metadata
+  }
 
-    return SqlSelectMetadata(
-      parameterNames = parameterNames,
-      columnAliases = columnAliases,
+  internal fun parseForValidation(sql: String): ParsedSql<SqlSelectMetadata> {
+    val parameterNames = NamedParameterSql.parse(sql).parameterNames.distinct()
+    val statement = parseStatement(sql)
+    val columnAliases = parseOutputColumns(statement)
+
+    return ParsedSql(
+      metadata = SqlSelectMetadata(
+        parameterNames = parameterNames,
+        columnAliases = columnAliases,
+      ),
+      statement = statement,
     )
   }
 
-  private fun parseOutputColumns(sql: String): List<String> {
+  private fun parseStatement(sql: String): PlainSelect {
     return try {
       val statement = CCJSqlParserUtil.parse(normalizeSql(sql))
       if (statement !is PlainSelect) {
         throw IllegalArgumentException("SQL API only supports SELECT statements")
       }
+      statement
+    } catch (e: IllegalArgumentException) {
+      throw e
+    } catch (e: Exception) {
+      throw IllegalArgumentException("Failed to parse SQL output columns: ${e.message}", e)
+    }
+  }
 
+  private fun parseOutputColumns(statement: PlainSelect): List<String> {
+    return try {
       val columnAliases = statement.selectItems.map { selectItem ->
         val selectField = selectItem.toString()
         if (selectField == "*" || selectField.endsWith(".*")) {

--- a/modules-web/zygarde-sql-api-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/sqlapi/SqlValidationRule.kt
+++ b/modules-web/zygarde-sql-api-codegen-dsl/src/main/kotlin/zygarde/codegen/dsl/sqlapi/SqlValidationRule.kt
@@ -1,0 +1,51 @@
+package zygarde.codegen.dsl.sqlapi
+
+import net.sf.jsqlparser.statement.Statement
+
+/**
+ * Inspects a successfully parsed SQL statement during SQL API code generation.
+ *
+ * [sql] is the original SQL supplied to the DSL. [statement] is the mutable JSqlParser 5.0 AST produced by the
+ * codegen parser and must be treated as read-only. Rules run synchronously in registration order and share the same
+ * statement instance. Return an empty list when the statement is valid.
+ */
+fun interface SqlValidationRule {
+  fun validate(sql: String, statement: Statement): List<String>
+}
+
+internal data class ParsedSql<M>(
+  val metadata: M,
+  val statement: Statement,
+)
+
+internal data class SqlStatementToValidate(
+  val role: String,
+  val sql: String,
+  val statement: Statement,
+)
+
+internal fun validateSqlStatements(
+  apiName: String,
+  declarationKind: String,
+  functionName: String,
+  rules: List<SqlValidationRule>,
+  statements: List<SqlStatementToValidate>,
+) {
+  val findings = statements.flatMap { statement ->
+    rules.flatMapIndexed { index, rule ->
+      try {
+        rule.validate(statement.sql, statement.statement).map { finding -> "${statement.role}: $finding" }
+      } catch (e: Exception) {
+        throw IllegalStateException(
+          "SQL validation rule #${index + 1} threw while validating ${statement.role} for " +
+            "SQL API '$apiName', $declarationKind '$functionName'",
+          e,
+        )
+      }
+    }
+  }
+  require(findings.isEmpty()) {
+    "SQL validation failed for SQL API '$apiName', $declarationKind '$functionName':\n" +
+      findings.joinToString("\n") { "- $it" }
+  }
+}

--- a/modules-web/zygarde-sql-api-codegen-dsl/src/test/kotlin/zygarde/codegen/dsl/sqlapi/SqlApiDslCodegenTest.kt
+++ b/modules-web/zygarde-sql-api-codegen-dsl/src/test/kotlin/zygarde/codegen/dsl/sqlapi/SqlApiDslCodegenTest.kt
@@ -5,11 +5,21 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import net.sf.jsqlparser.statement.Statement
 import org.junit.jupiter.api.Test
 import org.springframework.web.bind.annotation.RequestMethod
 import zygarde.sql.api.SqlApiContextParamResolver
 
 class SqlApiDslCodegenTest : SqlApiDslCodegen() {
+  private val validatedStatements: MutableList<Statement> = mutableListOf()
+
+  override val sqlValidationRules = listOf(
+    SqlValidationRule { _, statement ->
+      validatedStatements.add(statement)
+      emptyList()
+    },
+  )
+
   override fun codegen() {
     sqlApi("TodoReportApi", "/api/todo-report") {
       query("searchTodos", "/search") {
@@ -27,6 +37,13 @@ class SqlApiDslCodegenTest : SqlApiDslCodegen() {
         response("TodoReportDto")
       }
     }
+  }
+
+  @Test
+  fun `should apply codegen validation rules to declared SQL`() {
+    codegen()
+
+    validatedStatements.shouldHaveSize(1)
   }
 
   @Test

--- a/modules-web/zygarde-sql-api-codegen-dsl/src/test/kotlin/zygarde/codegen/dsl/sqlapi/SqlValidationRuleTest.kt
+++ b/modules-web/zygarde-sql-api-codegen-dsl/src/test/kotlin/zygarde/codegen/dsl/sqlapi/SqlValidationRuleTest.kt
@@ -1,0 +1,140 @@
+package zygarde.codegen.dsl.sqlapi
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import net.sf.jsqlparser.statement.Statement
+import net.sf.jsqlparser.statement.delete.Delete
+import net.sf.jsqlparser.statement.insert.Insert
+import net.sf.jsqlparser.statement.select.PlainSelect
+import net.sf.jsqlparser.statement.update.Update
+import org.junit.jupiter.api.Test
+
+class SqlValidationRuleTest {
+  @Test
+  fun `should expose original SQL and nested CTE AST to validation rules`() {
+    var validatedSql: String? = null
+    var validatedStatement: Statement? = null
+    val sql = """
+      with scoped_orders as (
+        select id, category
+        from resource_order
+        where category = :category
+      )
+      select id as id
+      from scoped_orders
+    """.trimIndent()
+    val api = dslSqlApi(
+      rules = listOf(
+        SqlValidationRule { originalSql, statement ->
+          validatedSql = originalSql
+          validatedStatement = statement
+          emptyList()
+        },
+      ),
+    ) {
+      query("findOrders", "/search") {
+        sql(sql)
+        param<String>("category")
+        column<Long>("id")
+      }
+    }
+
+    api.toSqlApiToGenerateVo()
+
+    validatedSql shouldBe sql
+    (validatedStatement is PlainSelect) shouldBe true
+    (validatedStatement as PlainSelect).withItemsList.single().toString() shouldContain "resource_order"
+  }
+
+  @Test
+  fun `should aggregate rule findings for main and count SQL in stable order`() {
+    val error = shouldThrow<IllegalArgumentException> {
+      dslSqlApi(
+        rules = listOf(
+          SqlValidationRule { _, _ -> listOf("first rule") },
+          SqlValidationRule { _, _ -> listOf("second rule") },
+        ),
+      ) {
+        query("pageOrders", "/search") {
+          sql("select id as id from resource_order limit :pageSize offset :offset")
+          returnsPage("select count(*) as totalCount from resource_order")
+          column<Long>("id")
+        }
+      }
+    }
+
+    error.message shouldBe """
+      SQL validation failed for SQL API 'OrderApi', query 'pageOrders':
+      - main SQL: first rule
+      - main SQL: second rule
+      - count SQL: first rule
+      - count SQL: second rule
+    """.trimIndent()
+  }
+
+  @Test
+  fun `should validate insert update and delete command statements`() {
+    val statementTypes = mutableListOf<Class<out Statement>>()
+    val api = dslSqlApi(
+      rules = listOf(
+        SqlValidationRule { _, statement ->
+          statementTypes.add(statement.javaClass)
+          emptyList()
+        },
+      ),
+    ) {
+      command("createOrder", "/create") {
+        sql("insert into resource_order(category) values (:category)")
+        param<String>("category")
+      }
+      command("updateOrder", "/update") {
+        sql("update resource_order set category = :category where id = :id")
+        param<String>("category")
+        param<Long>("id")
+      }
+      command("deleteOrder", "/delete") {
+        sql("delete from resource_order where id = :id")
+        param<Long>("id")
+      }
+    }
+
+    api.toSqlApiToGenerateVo()
+
+    statementTypes.shouldContainExactly(Insert::class.java, Update::class.java, Delete::class.java)
+  }
+
+  @Test
+  fun `should preserve validation rule exceptions as implementation failures`() {
+    val cause = IllegalStateException("broken rule")
+    val error = shouldThrow<IllegalStateException> {
+      dslSqlApi(
+        rules = listOf(SqlValidationRule { _, _ -> throw cause }),
+      ) {
+        command("deleteOrder", "/delete") {
+          sql("delete from resource_order where id = :id")
+          param<Long>("id")
+        }
+      }
+    }
+
+    error.message shouldBe
+      "SQL validation rule #1 threw while validating command SQL for SQL API 'OrderApi', command 'deleteOrder'"
+    error.cause shouldBe cause
+  }
+
+  private fun dslSqlApi(
+    rules: List<SqlValidationRule>,
+    dsl: DslSqlApi.() -> Unit,
+  ): DslSqlApi {
+    val config = SqlApiDslCodegenConfig(
+      dtoPackage = "generated.dto",
+      apiInterfacePackage = "generated.api",
+      controllerPackage = "generated.controller",
+      serviceInterfacePackage = "generated.service",
+      serviceImplPackage = "generated.service.impl",
+    )
+    return DslSqlApi(config, "OrderApi", "/orders", rules).also(dsl)
+  }
+}


### PR DESCRIPTION
## Summary

- add an opt-in `SqlValidationRule` extension point for project-specific SQL policies during SQL API code generation
- expose the original SQL and the already-parsed JSqlParser 5.0 `Statement` without parsing SQL a second time
- validate main query SQL, paged count SQL, and `INSERT` / `UPDATE` / `DELETE` commands
- aggregate findings with API name, function name, and SQL role while preserving rule registration order
- keep existing parser metadata, public constructors, generated models, and behavior unchanged when no rules are registered

## Motivation

`SqlSelectParser` and `SqlCommandParser` already build complete JSqlParser ASTs for built-in validation, but previously discarded them after extracting parameter, column, and command metadata. Downstream projects therefore had to parse SQL again or use regex for structural policies that must inspect nested CTEs, joins, subqueries, and DML statements.

The motivating downstream rule requires every SQL statement referencing `resource_order`, including references inside deeply nested CTEs, to contain an order-category predicate or an explicit exemption marker. A small proof of concept has already validated that this policy can be expressed against the existing AST on production SQL with six nested CTE levels.

## Usage

```kotlin
class OrderSqlApiCodegen : SqlApiDslCodegen() {
  override val sqlValidationRules = listOf(
    ResourceOrderCategoryRule,
  )

  override fun codegen() {
    // SQL API declarations
  }
}
```

Rules return validation findings, which codegen reports together:

```text
SQL validation failed for SQL API 'OrderApi', query 'pageOrders':
- main SQL: resource_order requires an order-category predicate
- count SQL: resource_order requires an order-category predicate
```

## Compatibility and API contract

- `SqlSelectMetadata` and `SqlCommandMetadata` remain unchanged.
- Existing public parser methods, DSL constructors, and zero-argument conversion methods remain available.
- Existing users that do not register rules retain the same behavior and generated output.
- JSqlParser is now an API dependency because `Statement` is part of the opt-in extension contract.
- The AST is mutable but validation rules must treat it as read-only. Rules run synchronously in registration order and share the statement instance after built-in metadata extraction.
- Comment-based exemption markers should be checked against the original SQL; structural checks should use the AST.

## Verification

- `./gradlew :zygarde-sql-api-codegen-dsl:test :zygarde-sql-api-codegen-dsl:ktlintCheck`
- `./gradlew test :zygarde-sql-api-codegen-dsl:detekt`
- nested CTE AST and original SQL coverage
- main/count finding aggregation and ordering coverage
- `INSERT`, `UPDATE`, and `DELETE` AST coverage
- validation-rule exception context and cause preservation coverage
- `git diff --check`