### PR TITLE
fix(jpa-codegen): generate combined Dao with field injection

### DIFF
--- a/docs/reference/kapt-options.md
+++ b/docs/reference/kapt-options.md
@@ -121,11 +121,16 @@ arg("zygarde.codegen.dao.combine", "true")
 Generated code (when true):
 ```kotlin
 @Component
-class Dao(
-  val book: BookDao,
-  val author: AuthorDao,
-  val category: CategoryDao
-)
+class Dao {
+  @Autowired
+  lateinit var book: BookDao
+
+  @Autowired
+  lateinit var author: AuthorDao
+
+  @Autowired
+  lateinit var category: CategoryDao
+}
 ```
 
 Usage:

--- a/modules-jpa/zygarde-jpa-codegen-ksp/README.md
+++ b/modules-jpa/zygarde-jpa-codegen-ksp/README.md
@@ -64,7 +64,10 @@ fun EnhancedSearch<Todo>.completed(): ComparableConditionAction<Todo, Todo, Bool
 3. **Dao.kt** - Combined DAO class (optional)
 ```kotlin
 @Component
-class Dao(@Autowired val todoDao: TodoDao)
+class Dao {
+  @Autowired
+  lateinit var todoDao: TodoDao
+}
 ```
 
 ## KSP Options

--- a/modules-jpa/zygarde-jpa-codegen-ksp/src/main/kotlin/zygarde/codegen/ksp/generator/ZygardeJpaDaoKspGenerator.kt
+++ b/modules-jpa/zygarde-jpa-codegen-ksp/src/main/kotlin/zygarde/codegen/ksp/generator/ZygardeJpaDaoKspGenerator.kt
@@ -128,8 +128,10 @@ class ZygardeJpaDaoKspGenerator(
     }
 
     if (options.getOrDefault(DAO_COMBINE, "true") == "true") {
+      // Field injection instead of constructor injection: JVM caps method parameters at 255
+      // slots and the reflective instantiation path trips a few slots earlier, so schemas
+      // with ~250 DAOs could no longer boot with a generated constructor.
       val classBuilder = TypeSpec.classBuilder("Dao").addAnnotation(Component::class)
-      val constructorBuilder = FunSpec.constructorBuilder()
 
       elements.sortedBy { it.asType(emptyList()).toTypeName().toString() }.forEach {
         val entityName = it.simpleName.asString()
@@ -139,23 +141,15 @@ class ZygardeJpaDaoKspGenerator(
         classBuilder.addProperty(
           PropertySpec
             .builder(daoFieldName, daoClass)
-            .initializer(daoFieldName)
+            .mutable()
+            .addModifiers(KModifier.LATEINIT)
             .addAnnotation(Autowired::class)
-            .build()
-        )
-        constructorBuilder.addParameter(
-          ParameterSpec
-            .builder(daoFieldName, daoClass)
             .build()
         )
       }
 
       FileSpec.builder(daoPackage, "Dao")
-        .addType(
-          classBuilder
-            .primaryConstructor(constructorBuilder.build())
-            .build()
-        )
+        .addType(classBuilder.build())
         .build()
         .writeTo(codeGenerator, aggregating = false)
     }

--- a/modules-jpa/zygarde-jpa-codegen-ksp/src/test/kotlin/zygarde/codegen/ksp/ZygardeJpaKspProcessorTest.kt
+++ b/modules-jpa/zygarde-jpa-codegen-ksp/src/test/kotlin/zygarde/codegen/ksp/ZygardeJpaKspProcessorTest.kt
@@ -43,6 +43,12 @@ class ZygardeJpaKspProcessorTest {
     generatedFileNames shouldContain "SimpleBookDaoExtensions.kt"
     generatedFileNames shouldContain "AutoIntIdBookDaoExtensions.kt"
     generatedFileNames shouldContain "AutoLongIdBookDaoExtensions.kt"
+    // combined Dao must use field injection — a generated constructor hits the JVM 255-param
+    // ceiling once the schema grows to ~250 DAOs
+    val combinedDao = generatedFiles.find { it.name == "Dao.kt" }!!.readText()
+    combinedDao shouldContain "lateinit var simpleBookDao: SimpleBookDao"
+    combinedDao shouldContain "@Autowired"
+    combinedDao shouldNotContain "public class Dao("
     val simpleBookDaoExtensions = generatedFiles.find { it.name == "SimpleBookDaoExtensions.kt" }!!.readText()
     simpleBookDaoExtensions shouldContain "fun SimpleBookDao.search("
     simpleBookDaoExtensions shouldContain "fun SimpleBookDao.searchOne("

--- a/modules-jpa/zygarde-jpa-codegen/src/main/kotlin/zygarde/codegen/generator/impl/ZygardeJpaDaoGenerator.kt
+++ b/modules-jpa/zygarde-jpa-codegen/src/main/kotlin/zygarde/codegen/generator/impl/ZygardeJpaDaoGenerator.kt
@@ -5,6 +5,7 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.ParameterSpec
@@ -129,8 +130,10 @@ class ZygardeJpaDaoGenerator(
     }
 
     if (processingEnv.options.getOrDefault(DAO_COMBINE, "true") == "true") {
+      // Field injection instead of constructor injection: JVM caps method parameters at 255
+      // slots and the reflective instantiation path trips a few slots earlier, so schemas
+      // with ~250 DAOs could no longer boot with a generated constructor.
       val classBuilder = TypeSpec.classBuilder("Dao").addAnnotation(Component::class)
-      val constructorBuilder = FunSpec.constructorBuilder()
 
       elements.sortedBy { it.typeName().toString() }.forEach {
         val daoFieldName = "${it.fieldName()}$daoSuffix"
@@ -138,23 +141,15 @@ class ZygardeJpaDaoGenerator(
         classBuilder.addProperty(
           PropertySpec
             .builder(daoFieldName, daoClass)
-            .initializer(daoFieldName)
+            .mutable()
+            .addModifiers(KModifier.LATEINIT)
             .addAnnotation(Autowired::class)
-            .build()
-        )
-        constructorBuilder.addParameter(
-          ParameterSpec
-            .builder(daoFieldName, daoClass)
             .build()
         )
       }
 
       FileSpec.builder(daoPackage, "Dao")
-        .addType(
-          classBuilder
-            .primaryConstructor(constructorBuilder.build())
-            .build()
-        )
+        .addType(classBuilder.build())
         .build()
         .writeTo(folderToGenerate)
     }

--- a/modules-jpa/zygarde-jpa-codegen/src/test/kotlin/zygarde/codegen/processor/ZygardeJpaDaoGeneratorTest.kt
+++ b/modules-jpa/zygarde-jpa-codegen/src/test/kotlin/zygarde/codegen/processor/ZygardeJpaDaoGeneratorTest.kt
@@ -40,6 +40,12 @@ class ZygardeJpaDaoGeneratorTest {
     generatedFileNames shouldContain "SimpleBookDaoExtensions.kt"
     generatedFileNames shouldContain "AutoIntIdBookDaoExtensions.kt"
     generatedFileNames shouldContain "AutoLongIdBookDaoExtensions.kt"
+    // combined Dao must use field injection — a generated constructor hits the JVM 255-param
+    // ceiling once the schema grows to ~250 DAOs
+    val combinedDao = result.generatedFiles.find { it.name == "Dao.kt" }!!.readText()
+    combinedDao shouldContain "lateinit var simpleBookDao: SimpleBookDao"
+    combinedDao shouldContain "@Autowired"
+    combinedDao shouldNotContain "public class Dao("
     val simpleBookDaoExtensions = result.generatedFiles.find { it.name == "SimpleBookDaoExtensions.kt" }!!.readText()
     simpleBookDaoExtensions shouldContain "fun SimpleBookDao.search("
     simpleBookDaoExtensions shouldContain "fun SimpleBookDao.searchOne("


### PR DESCRIPTION
Fixes #27

## Problem

The combined `Dao` aggregate is generated with constructor injection — one constructor parameter per DAO. The JVM caps method parameters at 255 slots, and the Kotlin-reflect instantiation path trips a few slots earlier, so once a schema grows to ~250 DAOs the Spring context fails to start:

```
BeanInstantiationException: Failed to instantiate [....codegen.data.dao.Dao]
Caused by: java.lang.IllegalArgumentException: bad parameter count 256
```

Empirical boundary (Spring Boot 3, Kotlin): 240 constructor params boot fine, 252 fail.

## Change

Generate the combined `Dao` with field injection instead, in both the **kapt** and **KSP** generators:

```kotlin
@Component
class Dao {
  @Autowired
  lateinit var bookDao: BookDao
  // ...
}
```

- No parameter limit — scales to any DAO count.
- Source-compatible for call sites: consumers only read `dao.xxxDao` properties; construction is Spring's job.
- Docs samples updated (`docs/reference/kapt-options.md`, KSP README).
- Existing generator tests extended to assert the field-injected shape and reject a generated constructor.

`:zygarde-jpa-codegen:test`, `:zygarde-jpa-codegen-ksp:test` and `ktlintCheck` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
